### PR TITLE
First iteration of UI modification

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,8 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Address App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
+         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -23,7 +24,7 @@
         <URL value="@Extensions.css" />
       </stylesheets>
 
-            <VBox>
+      <VBox>
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
@@ -32,47 +33,43 @@
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
           </Menu>
         </MenuBar>
-            <SplitPane dividerPositions="0.5, 0.5" prefHeight="160.0" prefWidth="200.0">
-              <items>
-                  <VBox prefHeight="200.0" prefWidth="220.0">
-                     <children>
-                        <StackPane fx:id="leftCol" prefHeight="150.0" prefWidth="200.0" />
-                     </children>
-                  </VBox>
-                  <VBox prefHeight="200.0" prefWidth="100.0">
-                     <children>
-            
-                          <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
+
+          <SplitPane VBox.vgrow="NEVER" fx:id="mainSplit">
+              <VBox prefHeight="200.0" prefWidth="220.0">
+                  <StackPane fx:id="leftCol" prefHeight="150.0" prefWidth="200.0"/>
+              </VBox>
+
+              <VBox>
+                  <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
                       <padding>
-                        <Insets bottom="5" left="10" right="10" top="5" />
+                          <Insets bottom="5" left="10" right="10" top="5"/>
                       </padding>
-                    </StackPane>
-            
-                          <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                  </StackPane>
+
+                  <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100"
+                             styleClass="pane-with-border" VBox.vgrow="NEVER">
                       <padding>
-                        <Insets bottom="5" left="10" right="10" top="5" />
+                          <Insets bottom="5" left="10" right="10" top="5"/>
                       </padding>
-                    </StackPane>
-            
-                          <VBox fx:id="personList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                  </StackPane>
+
+                  <VBox fx:id="personList" minWidth="340" prefWidth="340" styleClass="pane-with-border"
+                        VBox.vgrow="ALWAYS">
                       <padding>
-                        <Insets bottom="10" left="10" right="10" top="10" />
+                          <Insets bottom="10" left="10" right="10" top="10"/>
                       </padding>
-                           <children>
-                         <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
-                           </children>
-                    </VBox>
-            
-                          <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-                     </children>
+                      <children>
+                          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                      </children>
                   </VBox>
-                  <VBox prefHeight="200.0" prefWidth="100.0">
-                     <children>
-                        <StackPane fx:id="rightCol" prefHeight="150.0" prefWidth="200.0" />
-                     </children>
-                  </VBox>
-              </items>
-            </SplitPane>
+
+                  <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
+              </VBox>
+
+              <VBox prefHeight="200.0" prefWidth="100.0">
+                  <StackPane fx:id="rightCol" prefHeight="150.0" prefWidth="200.0"/>
+              </VBox>
+          </SplitPane>
       </VBox>
     </Scene>
   </scene>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -10,9 +10,9 @@
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.stage.Stage?>
 
-<fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1"
-         title="Address App" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
+<fx:root minHeight="600" minWidth="450" onCloseRequest="#handleExit" title="Address App" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/address_book_32.png" />
   </icons>
@@ -23,7 +23,7 @@
         <URL value="@Extensions.css" />
       </stylesheets>
 
-      <VBox>
+            <VBox>
         <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
           <Menu mnemonicParsing="false" text="File">
             <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
@@ -32,28 +32,47 @@
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
           </Menu>
         </MenuBar>
-
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
-
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
-
-        <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
-
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+            <SplitPane dividerPositions="0.5, 0.5" prefHeight="160.0" prefWidth="200.0">
+              <items>
+                  <VBox prefHeight="200.0" prefWidth="220.0">
+                     <children>
+                        <StackPane fx:id="leftCol" prefHeight="150.0" prefWidth="200.0" />
+                     </children>
+                  </VBox>
+                  <VBox prefHeight="200.0" prefWidth="100.0">
+                     <children>
+            
+                          <StackPane fx:id="commandBoxPlaceholder" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                      <padding>
+                        <Insets bottom="5" left="10" right="10" top="5" />
+                      </padding>
+                    </StackPane>
+            
+                          <StackPane fx:id="resultDisplayPlaceholder" maxHeight="100" minHeight="100" prefHeight="100" styleClass="pane-with-border" VBox.vgrow="NEVER">
+                      <padding>
+                        <Insets bottom="5" left="10" right="10" top="5" />
+                      </padding>
+                    </StackPane>
+            
+                          <VBox fx:id="personList" minWidth="340" prefWidth="340" styleClass="pane-with-border" VBox.vgrow="ALWAYS">
+                      <padding>
+                        <Insets bottom="10" left="10" right="10" top="10" />
+                      </padding>
+                           <children>
+                         <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS" />
+                           </children>
+                    </VBox>
+            
+                          <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
+                     </children>
+                  </VBox>
+                  <VBox prefHeight="200.0" prefWidth="100.0">
+                     <children>
+                        <StackPane fx:id="rightCol" prefHeight="150.0" prefWidth="200.0" />
+                     </children>
+                  </VBox>
+              </items>
+            </SplitPane>
       </VBox>
     </Scene>
   </scene>


### PR DESCRIPTION
New branch ui-v1.2 to implement new 3 column UI in parallel.

This splits the current screen in to 3 parts, left column, centre column (existing screen), right column. The left and right columns are empty for now but are resizable with respect to the centre column.

![image](https://user-images.githubusercontent.com/116437490/222910736-c564a231-4864-43b8-a4e6-25bc5946772b.png)

Todo: Add new classes under Ui package to support Ui in left and right columns.