### PR TITLE
[GUI] Implement more concise display for PersonListCard

### DIFF
--- a/src/main/java/codoc/logic/commands/ViewCommand.java
+++ b/src/main/java/codoc/logic/commands/ViewCommand.java
@@ -23,9 +23,9 @@ public class ViewCommand extends Command {
             + "by the index number used in the displayed person list "
             + "or by different tab names (c/m/s)\n";
 
-    public static final String MESSAGE_VIEW_PERSON_SUCCESS = "Viewing %1$d";
+    public static final String MESSAGE_VIEW_PERSON_SUCCESS = "Viewing details of %1$s at index %2$d";
 
-    public static final String MESSAGE_CHANGE_TAB_SUCCESS = "Viewing %1$s";
+    public static final String MESSAGE_CHANGE_TAB_SUCCESS = "Viewing detailed %1$s information";
 
     private final Index index;
 
@@ -56,7 +56,17 @@ public class ViewCommand extends Command {
 
         if (tab.equals("c") || tab.equals("m") || tab.equals("s")) { // If it is view tab
             model.setCurrentTab(tab);
-            return new CommandResult(String.format(MESSAGE_CHANGE_TAB_SUCCESS, tab));
+            String tabName = "";
+            if (tab.equals("c")) {
+                tabName = "contact";
+            }
+            if (tab.equals("m")) {
+                tabName = "module";
+            }
+            if (tab.equals("s")) {
+                tabName = "skill";
+            }
+            return new CommandResult(String.format(MESSAGE_CHANGE_TAB_SUCCESS, tabName));
         }
 
         if (index.getZeroBased() >= lastShownList.size()) {
@@ -66,7 +76,8 @@ public class ViewCommand extends Command {
         // View index
         Person protagonist = lastShownList.get(index.getZeroBased());
         model.setProtagonist(protagonist);
+        String[] nameParsed = protagonist.getName().toString().split(" ", 2);
 
-        return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, index.getOneBased()));
+        return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, nameParsed[0], index.getOneBased()));
     }
 }

--- a/src/main/java/codoc/ui/PersonCard.java
+++ b/src/main/java/codoc/ui/PersonCard.java
@@ -33,13 +33,11 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label id;
     @FXML
-    private Label github;
+    private Label course;
     @FXML
-    private Label linkedin;
+    private Label year;
     @FXML
     private Label email;
-    @FXML
-    private FlowPane skills;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -49,12 +47,9 @@ public class PersonCard extends UiPart<Region> {
         this.person = person;
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
-        github.setText(person.getGithub().value);
-        linkedin.setText(person.getLinkedin().value);
+        year.setText("Year " + person.getYear().year);
+        course.setText(person.getCourse().course);
         email.setText(person.getEmail().value);
-        person.getSkills().stream()
-                .sorted(Comparator.comparing(skill -> skill.skillName))
-                .forEach(skill -> skills.getChildren().add(new Label(skill.skillName)));
     }
 
     @Override

--- a/src/main/java/codoc/ui/PersonCard.java
+++ b/src/main/java/codoc/ui/PersonCard.java
@@ -1,11 +1,8 @@
 package codoc.ui;
 
-import java.util.Comparator;
-
 import codoc.model.person.Person;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -1,35 +1,33 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.ColumnConstraints?>
-<?import javafx.scene.layout.FlowPane?>
-<?import javafx.scene.layout.GridPane?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.VBox?>
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.geometry.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17.0.2-ea" xmlns:fx="http://javafx.com/fxml/1">
   <GridPane HBox.hgrow="ALWAYS">
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
+        <Insets bottom="5" left="15" right="5" top="5" />
       </padding>
-      <HBox spacing="5" alignment="CENTER_LEFT">
+      <HBox alignment="CENTER_LEFT" spacing="5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
-      <FlowPane fx:id="skills" />
-      <Label fx:id="github" styleClass="cell_small_label" text="\$github" />
-      <Label fx:id="linkedin" styleClass="cell_small_label" text="\$linkedin" />
+      <Label fx:id="year" styleClass="cell_small_label" text="\$year" />
+      <Label fx:id="course" styleClass="cell_small_label" text="\$course" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
+      <rowConstraints>
+         <RowConstraints />
+      </rowConstraints>
   </GridPane>
 </HBox>


### PR DESCRIPTION
## Update GUI to improve readability

### PersonListCard

As @linustws suggested in our discussion, I have modified the `PersonListCard` to show only the compulsory parameters for `Person`. This will update it to show name, year and course of study, email of a person (removed skills/GitHub/LinkedIn).

| Old card | New card |
| ------------- | ------------- |
| ![old_personcard](https://user-images.githubusercontent.com/116437490/225579617-8fe4555e-6380-450f-a72b-f2f0dbe551e8.PNG) | ![new_personcard](https://user-images.githubusercontent.com/116437490/225579655-ba009922-7757-46f5-8f51-2e480d8b7fe0.PNG) |

### ResultDisplay

The result of command execution for `ViewCommand` is improved to show more information about its results, such as name of the `protagonist` being displayed and the exact `tab` name InfoPanel is displaying.


**1. View INDEX command:**
| Old CommandResult | New CommandResult |
| ------------- | ------------- |
| ![old_view_index](https://user-images.githubusercontent.com/116437490/225581476-3468dd60-2f22-4d14-a3cc-1c41472c03f4.PNG) | ![new_view_index](https://user-images.githubusercontent.com/116437490/225581743-d9bb8f3b-028b-4b62-ab19-f05c24e21bdb.PNG) |

**2. View TAB command:**
| Old CommandResult | New CommandResult |
| ------------- | ------------- |
| ![old_view_tab](https://user-images.githubusercontent.com/116437490/225581901-1ccf8892-8e79-4755-89f3-57e5a680dc38.PNG) | ![new_view_tab](https://user-images.githubusercontent.com/116437490/225581996-a3596ac9-4788-4892-a667-fa64967d2f55.PNG) |


## Summary

Current UI of Codoc has unclear/unnecessary information shown. These has been improved through this update.