### PR TITLE
Change find OR to AND and change finding of name, year, course to contains instead of containsword

### DIFF
--- a/src/main/java/codoc/logic/parser/FindCommandParser.java
+++ b/src/main/java/codoc/logic/parser/FindCommandParser.java
@@ -12,12 +12,12 @@ import java.util.function.Predicate;
 
 import codoc.logic.commands.FindCommand;
 import codoc.logic.parser.exceptions.ParseException;
-import codoc.model.module.ModuleContainsKeywordPredicate;
+import codoc.model.module.ModuleContainsKeywordsPredicate;
 import codoc.model.person.CourseContainsKeywordsPredicate;
 import codoc.model.person.NameContainsKeywordsPredicate;
 import codoc.model.person.Person;
 import codoc.model.person.YearContainsKeywordsPredicate;
-import codoc.model.skill.SkillContainsKeywordPredicate;
+import codoc.model.skill.SkillContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -50,43 +50,66 @@ public class FindCommandParser implements Parser<FindCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
 
-        String nameArgs = argMultimap.getValue(PREFIX_NAME).orElseGet(() -> "").trim();
-        String yearArgs = argMultimap.getValue(PREFIX_YEAR).orElseGet(() -> "").trim();
-        String courseArgs = argMultimap.getValue(PREFIX_COURSE).orElseGet(() -> "").trim();
-        String skillArgs = argMultimap.getValue(PREFIX_SKILL).orElseGet(() -> "").trim();
-        String moduleArgs = argMultimap.getValue(PREFIX_MOD).orElseGet(() -> "").trim();
+        Predicate<Person> combinedPredicate = person -> true;
+        combinedPredicate = addNamePredicate(argMultimap, combinedPredicate);
+        combinedPredicate = addYearPredicate(argMultimap, combinedPredicate);
+        combinedPredicate = addCoursePredicate(argMultimap, combinedPredicate);
+        combinedPredicate = addSkillPredicate(argMultimap, combinedPredicate);
+        combinedPredicate = addModulePredicate(argMultimap, combinedPredicate);
 
-        String[] nameKeywords = !nameArgs.isEmpty() ? nameArgs.split("\\s+") : new String[0];
-        String[] yearKeywords = !yearArgs.isEmpty() ? yearArgs.split("\\s+") : new String[0];
-        String[] courseKeywords = !courseArgs.isEmpty() ? courseArgs.split("\\s+") : new String[0];
-        String[] skillKeywords = !skillArgs.isEmpty() ? skillArgs.split("\\s+") : new String[0];
-        String[] moduleKeywords = !moduleArgs.isEmpty() ? moduleArgs.split("\\s+") : new String[0];
-
-        Predicate<Person> namePredicate = nameKeywords.length > 0
-                ? new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords))
-                : person -> false;
-        Predicate<Person> yearPredicate = yearKeywords.length > 0
-                ? new YearContainsKeywordsPredicate(Arrays.asList(yearKeywords))
-                : person -> false;
-        Predicate<Person> coursePredicate = courseKeywords.length > 0
-                ? new CourseContainsKeywordsPredicate(Arrays.asList(courseKeywords))
-                : person -> false;
-        Predicate<Person> skillPredicate = skillKeywords.length > 0
-                ? new SkillContainsKeywordPredicate(Arrays.asList(skillKeywords))
-                : person -> false;
-        Predicate<Person> modulePredicate = moduleKeywords.length > 0
-                ? new ModuleContainsKeywordPredicate(Arrays.asList(moduleKeywords))
-                : person -> false;
-
-        Predicate<Person> combinedPredicate = namePredicate
-                .or(yearPredicate)
-                .or(coursePredicate)
-                .or(skillPredicate)
-                .or(modulePredicate);
 
         return new FindCommand(
                 combinedPredicate
         );
+    }
+    private Predicate<Person> addNamePredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+        String nameArgs = argMultimap.getValue(PREFIX_NAME).orElseGet(() -> "").trim();
+        if (!nameArgs.isEmpty()) {
+            String[] nameKeywords = nameArgs.split("\\s+");
+            Predicate<Person> namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            combinedPredicate = combinedPredicate.and(namePredicate);
+        }
+        return combinedPredicate;
+    }
+
+    private Predicate<Person> addYearPredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+        String yearArgs = argMultimap.getValue(PREFIX_YEAR).orElseGet(() -> "").trim();
+        if (!yearArgs.isEmpty()) {
+            String[]yearKeywords = yearArgs.split("\\s+");
+            Predicate<Person> yearPredicate = new YearContainsKeywordsPredicate(Arrays.asList(yearKeywords));
+            combinedPredicate = combinedPredicate.and(yearPredicate);
+        }
+        return combinedPredicate;
+    }
+
+    private Predicate<Person> addCoursePredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+        String courseArgs = argMultimap.getValue(PREFIX_COURSE).orElseGet(() -> "").trim();
+        if (!courseArgs.isEmpty()) {
+            String[] courseKeywords = courseArgs.split("\\s+");
+            Predicate<Person> coursePredicate = new CourseContainsKeywordsPredicate(Arrays.asList(courseKeywords));
+            combinedPredicate = combinedPredicate.and(coursePredicate);
+        }
+        return combinedPredicate;
+    }
+
+    private Predicate<Person> addSkillPredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+        String skillArgs = argMultimap.getValue(PREFIX_SKILL).orElseGet(() -> "").trim();
+        if (!skillArgs.isEmpty()) {
+            String[] skillKeywords = skillArgs.split("\\s+");
+            Predicate<Person> skillPredicate = new SkillContainsKeywordsPredicate(Arrays.asList(skillKeywords));
+            combinedPredicate = combinedPredicate.and(skillPredicate);
+        }
+        return combinedPredicate;
+    }
+
+    private Predicate<Person> addModulePredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+        String moduleArgs = argMultimap.getValue(PREFIX_MOD).orElseGet(() -> "").trim();
+        if (!moduleArgs.isEmpty()) {
+            String[] moduleKeywords = moduleArgs.split("\\s+");
+            Predicate<Person> modulePredicate = new ModuleContainsKeywordsPredicate(Arrays.asList(moduleKeywords));
+            combinedPredicate = combinedPredicate.and(modulePredicate);
+        }
+        return combinedPredicate;
     }
 
 }

--- a/src/main/java/codoc/model/module/ModuleContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/module/ModuleContainsKeywordsPredicate.java
@@ -8,12 +8,12 @@ import codoc.model.person.Person;
 /**
  * Tests that a {@code Person}'s {@code Module} matches any of the keywords given.
  */
-public class ModuleContainsKeywordPredicate implements Predicate<Person> {
+public class ModuleContainsKeywordsPredicate implements Predicate<Person> {
     public static final String ACAD_YEAR_VALIDATION_REGEX = "^AY[0-9]{4}S[12]";
 
     private final List<String> keywords;
 
-    public ModuleContainsKeywordPredicate(List<String> keywords) {
+    public ModuleContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -42,7 +42,7 @@ public class ModuleContainsKeywordPredicate implements Predicate<Person> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof ModuleContainsKeywordPredicate // instanceof handles nulls
-                && keywords.equals(((ModuleContainsKeywordPredicate) other).keywords)); // state check
+                || (other instanceof ModuleContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((ModuleContainsKeywordsPredicate) other).keywords)); // state check
     }
 }

--- a/src/main/java/codoc/model/person/CourseContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/CourseContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package codoc.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import codoc.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Course} matches any of the keywords given.
  */
@@ -18,7 +16,7 @@ public class CourseContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getCourse().course, keyword));
+                .anyMatch(keyword -> person.getCourse().course.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/codoc/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/NameContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package codoc.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import codoc.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
  */
@@ -18,7 +16,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+                .anyMatch(keyword -> person.getName().fullName.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/codoc/model/person/YearContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/YearContainsKeywordsPredicate.java
@@ -3,8 +3,6 @@ package codoc.model.person;
 import java.util.List;
 import java.util.function.Predicate;
 
-import codoc.commons.util.StringUtil;
-
 /**
  * Tests that a {@code Person}'s {@code Year} matches any of the keywords given.
  */
@@ -18,7 +16,7 @@ public class YearContainsKeywordsPredicate implements Predicate<Person> {
     @Override
     public boolean test(Person person) {
         return keywords.stream()
-                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getYear().year, keyword));
+                .anyMatch(keyword -> person.getYear().year.toLowerCase().contains(keyword.toLowerCase()));
     }
 
     @Override

--- a/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
@@ -8,10 +8,10 @@ import codoc.model.person.Person;
 /**
  * Tests that a {@code Person}'s {@code Skill} matches any of the keywords given.
  */
-public class SkillContainsKeywordPredicate implements Predicate<Person> {
+public class SkillContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 
-    public SkillContainsKeywordPredicate(List<String> keywords) {
+    public SkillContainsKeywordsPredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -26,7 +26,7 @@ public class SkillContainsKeywordPredicate implements Predicate<Person> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof SkillContainsKeywordPredicate // instanceof handles nulls
-                && keywords.equals(((SkillContainsKeywordPredicate) other).keywords)); // state check
+                || (other instanceof SkillContainsKeywordsPredicate // instanceof handles nulls
+                && keywords.equals(((SkillContainsKeywordsPredicate) other).keywords)); // state check
     }
 }

--- a/src/main/java/codoc/model/util/SampleDataUtil.java
+++ b/src/main/java/codoc/model/util/SampleDataUtil.java
@@ -30,7 +30,7 @@ public class SampleDataUtil {
                     new Email("alexyeoh@example.com"),
                     new Linkedin("linkedin.com/in/alexyeoh"),
                     getSkillSet("python"),
-                    getModuleSet("AY2223S2 CS1101")
+                    getModuleSet("AY2223S2 CS1101S")
             ),
             new Person(
                     new Name("Bernice Yu"),
@@ -40,7 +40,7 @@ public class SampleDataUtil {
                     new Email("berniceyu@example.com"),
                     new Linkedin("linkedin.com/in/berNICE"),
                     getSkillSet("java", "python"),
-                    getModuleSet("AY2223S2 CS1101", "AY2223S2 CS2030S")
+                    getModuleSet("AY2223S2 CS1101S")
             ),
             new Person(
                     new Name("Charlotte Oliveiro"),
@@ -50,7 +50,7 @@ public class SampleDataUtil {
                     new Email("charlotte@example.com"),
                     new Linkedin("linkedin.com/in/charlotte-oliveiro"),
                     getSkillSet("sql"),
-                    getModuleSet("AY2223S2 CS1101", "AY2223S2 CS2030S", "AY2223S2 CS2040S")
+                    getModuleSet("AY2223S2 CS2030S", "AY2223S2 CS2040S")
             ),
             new Person(
                     new Name("David Li"),
@@ -60,7 +60,7 @@ public class SampleDataUtil {
                     new Email("lidavid@example.com"),
                     new Linkedin("linkedin.com/in/d4v1d-l1"),
                     getSkillSet("c"),
-                    getModuleSet("AY2223S2 CS1101", "AY2223S2 CS2030S")
+                    getModuleSet("AY2223S2 CS2030S")
             ),
             new Person(
                     new Name("Irfan Ibrahim"),
@@ -70,7 +70,7 @@ public class SampleDataUtil {
                     new Email("irfan@example.com"),
                     new Linkedin("linkedin.com/in/1rf4n"),
                     getSkillSet("javascript"),
-                    getModuleSet("AY2223S2 CS1101", "AY2223S2 CS2030S")
+                    getModuleSet("AY2223S2 CS2040S")
             ),
             new Person(
                     new Name("Roy Balakrishnan"),
@@ -80,8 +80,18 @@ public class SampleDataUtil {
                     new Email("royb@example.com"),
                     new Linkedin("linkedin.com/in/Roy"),
                     getSkillSet("java"),
-                    getModuleSet("AY2223S2 CS1101", "AY2223S2 CS2030S")
-            )
+                    getModuleSet("AY2223S2 CS2109S")
+            ),
+            new Person(
+                    new Name("Roy Boy"),
+                    new Course("CEG"),
+                    new Year("4"),
+                    new Github("b4l4Kr15H-n4nn"),
+                    new Email("royboy@example.com"),
+                    new Linkedin("linkedin.com/in/Royyy"),
+                    getSkillSet("python"),
+                    getModuleSet("AY2223S2 CS2103T", "AY2223S2 CS2109S")
+            ),
         };
     }
 


### PR DESCRIPTION
Closes #80.

- made helper functions to improve code quality of findcommandparser class
- added new person in sampledatautil to test for different people with the same name: Roy
- now filteredlist contains people that must satisfy all predicates specified by user instead of just one.
- using contains instead of containsword is less restrictive for users
- _test cases still not fixed/added yet._ 
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/97421565/225852691-eda85d93-bfa0-42af-b522-6ba175ca4ff2.png">
