### PR TITLE
Fix potential ui bug

### DIFF
--- a/src/main/java/codoc/ui/infopanel/InfoTab.java
+++ b/src/main/java/codoc/ui/infopanel/InfoTab.java
@@ -51,7 +51,7 @@ public class InfoTab extends UiPart<Region> {
             sb.append("Year ");
             sb.append(protagonist.getYear());
             sb.append(", ");
-            sb.append(protagonist.getCourse());
+            sb.append(protagonist.getCourse().toString());
             identity.setText(sb.toString());
             detailedInfoPlaceholder.getChildren().add(detailedInfo.getRoot());
         }


### PR DESCRIPTION
Noticed a new bug emerging after the latest PR #88. This occurred because Course is now in a different form and package and existing codoc.json data will conflict with it. As we all know, our current approach to this is to reset your database, but this made me look into the code again to see if there are more ripple effects.

![image](https://user-images.githubusercontent.com/116437490/226620688-457b4210-22c0-4c3a-b1ac-a0ecdd6a3b3d.png)

**How to recreate this error:**
1. Check out any of the previous commits before #88 and delete codoc.json.
2. Run the program in the IDE to recreate a fresh database.
3. Exit the program then check out the latest master head in the upstream.
4. Run the program again.

**Cause of this bug:**

The main problem is the database conflicting, but I also noticed that previously Person contained Course as String, but it is now a Course class. This could result in more breaks during instantiating InfoPanel (`InfoTab` class, actually I should rename these for consistency), where it tries to append person's course to the description but fail as it is not a String, depending on the implementation of Person and Course. This could result in a situation where InfoPanel is not properly generated and stay in its default placeholder.

Simple fix has been implemented by adding a toString(), so that it will not be heavily affected by any modifications to the classes it is referring to (Open-closed principle).

Previously (in `codoc/ui/infopanel/InfoTab`):

```java
sb.append(protagonist.getCourse());
```
After the fix:
```java
sb.append(protagonist.getCourse().toString());
```

**Implications:**
This alerted us for more potential bugs occurring when we modify the Model if some components are heavily reliant on implementation of another component. I believe Ui is the most vulnerable for this mistake of not following the Open-closed principle since it interacts with every other component, so I will make sure to be careful.