### PR TITLE
Show Find History

### DIFF
--- a/src/main/java/codoc/logic/commands/EditCommand.java
+++ b/src/main/java/codoc/logic/commands/EditCommand.java
@@ -122,7 +122,7 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.setProtagonist(editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS, "");
 
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson));
     }

--- a/src/main/java/codoc/logic/commands/FindCommand.java
+++ b/src/main/java/codoc/logic/commands/FindCommand.java
@@ -23,22 +23,24 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " n/alice bob charlie y/2 3 c/computer business";
 
     private final Predicate<Person> predicate;
-    private final String userInput;
+    private final String userInputs;
 
-    public FindCommand(Predicate<Person> predicate, String userInput) {
+    /**
+     * @param predicate to filter out contacts
+     * @param userInputs inputs that were used to create the predicate
+     */
+    public FindCommand(Predicate<Person> predicate, String userInputs) {
         this.predicate = predicate;
-        this.userInput = userInput;
+        this.userInputs = userInputs;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        String s = model.updateFilteredPersonList(predicate, userInput);
+        String appliedPredicates = model.updateFilteredPersonList(predicate, userInputs);
         return new CommandResult(
-                //String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
-                //String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, userInput);
-                s);
-
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW.concat("\n").concat(appliedPredicates),
+                        model.getFilteredPersonList().size()));
     }
 
     @Override

--- a/src/main/java/codoc/logic/commands/FindCommand.java
+++ b/src/main/java/codoc/logic/commands/FindCommand.java
@@ -23,17 +23,22 @@ public class FindCommand extends Command {
             + "Example: " + COMMAND_WORD + " n/alice bob charlie y/2 3 c/computer business";
 
     private final Predicate<Person> predicate;
+    private final String userInput;
 
-    public FindCommand(Predicate<Person> predicate) {
+    public FindCommand(Predicate<Person> predicate, String userInput) {
         this.predicate = predicate;
+        this.userInput = userInput;
     }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        String s = model.updateFilteredPersonList(predicate, userInput);
         return new CommandResult(
-                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                //String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+                //String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, userInput);
+                s);
+
     }
 
     @Override

--- a/src/main/java/codoc/logic/commands/ListCommand.java
+++ b/src/main/java/codoc/logic/commands/ListCommand.java
@@ -18,7 +18,7 @@ public class ListCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS, "");
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/codoc/logic/parser/FindCommandParser.java
+++ b/src/main/java/codoc/logic/parser/FindCommandParser.java
@@ -24,6 +24,16 @@ import codoc.model.skill.SkillContainsKeywordsPredicate;
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
+    private class PredicateStringPair {
+        private Predicate<Person> predicate;
+        private String string;
+
+        private PredicateStringPair(Predicate<Person> predicate, String string) {
+            this.predicate = predicate;
+            this.string = string;
+        }
+    }
+
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
@@ -58,7 +68,8 @@ public class FindCommandParser implements Parser<FindCommand> {
         combinedPredicate = addSkillPredicate(argMultimap, combinedPredicate);
 
         return new FindCommand(
-                combinedPredicate
+                combinedPredicate,
+                trimmedArgs
         );
     }
     private Predicate<Person> addNamePredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {

--- a/src/main/java/codoc/logic/parser/FindCommandParser.java
+++ b/src/main/java/codoc/logic/parser/FindCommandParser.java
@@ -29,12 +29,12 @@ public class FindCommandParser implements Parser<FindCommand> {
         private String string;
 
         private PredicateStringPair() {
-            this.predicate = person -> true;;
+            this.predicate = person -> true;
             this.string = "";
         }
 
         private void appendString(String s) {
-            this.string = this.string.concat(s);
+            this.string = this.string.concat(" ").concat(s);
         }
         private void combinePredicate(Predicate<Person> namePredicate) {
             this.predicate = this.predicate.and(namePredicate);

--- a/src/main/java/codoc/logic/parser/FindCommandParser.java
+++ b/src/main/java/codoc/logic/parser/FindCommandParser.java
@@ -24,13 +24,26 @@ import codoc.model.skill.SkillContainsKeywordsPredicate;
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
-    private class PredicateStringPair {
+    private static class PredicateStringPair {
         private Predicate<Person> predicate;
         private String string;
 
-        private PredicateStringPair(Predicate<Person> predicate, String string) {
-            this.predicate = predicate;
-            this.string = string;
+        private PredicateStringPair() {
+            this.predicate = person -> true;;
+            this.string = "";
+        }
+
+        private void appendString(String s) {
+            this.string = this.string.concat(s);
+        }
+        private void combinePredicate(Predicate<Person> namePredicate) {
+            this.predicate = this.predicate.and(namePredicate);
+        }
+        private Predicate<Person> getPredicate() {
+            return this.predicate;
+        }
+        private String getString() {
+            return this.string;
         }
     }
 
@@ -59,67 +72,65 @@ public class FindCommandParser implements Parser<FindCommand> {
         if (!argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
+        PredicateStringPair psp = new PredicateStringPair();
+        addNamePredicate(argMultimap, psp);
+        addYearPredicate(argMultimap, psp);
+        addCoursePredicate(argMultimap, psp);
+        addModulePredicate(argMultimap, psp);
+        addSkillPredicate(argMultimap, psp);
 
-        Predicate<Person> combinedPredicate = person -> true;
-        combinedPredicate = addNamePredicate(argMultimap, combinedPredicate);
-        combinedPredicate = addYearPredicate(argMultimap, combinedPredicate);
-        combinedPredicate = addCoursePredicate(argMultimap, combinedPredicate);
-        combinedPredicate = addModulePredicate(argMultimap, combinedPredicate);
-        combinedPredicate = addSkillPredicate(argMultimap, combinedPredicate);
+        return new FindCommand(psp.getPredicate(), psp.getString());
 
-        return new FindCommand(
-                combinedPredicate,
-                trimmedArgs
-        );
     }
-    private Predicate<Person> addNamePredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+
+    private void addNamePredicate(ArgumentMultimap argMultimap, PredicateStringPair psp) {
         String nameArgs = argMultimap.getValue(PREFIX_NAME).orElse("").trim();
         if (!nameArgs.isEmpty()) {
             String[] nameKeywords = nameArgs.split("\\s+");
             Predicate<Person> namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
-            combinedPredicate = combinedPredicate.and(namePredicate);
+            psp.appendString(namePredicate.toString());
+            psp.combinePredicate(namePredicate);
         }
-        return combinedPredicate;
     }
 
-    private Predicate<Person> addYearPredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+    private void addYearPredicate(ArgumentMultimap argMultimap, PredicateStringPair psp) {
         String yearArgs = argMultimap.getValue(PREFIX_YEAR).orElse("").trim();
         if (!yearArgs.isEmpty()) {
             String[]yearKeywords = yearArgs.split("\\s+");
             Predicate<Person> yearPredicate = new YearContainsKeywordsPredicate(Arrays.asList(yearKeywords));
-            combinedPredicate = combinedPredicate.and(yearPredicate);
+            psp.appendString(yearPredicate.toString());
+            psp.combinePredicate(yearPredicate);
         }
-        return combinedPredicate;
     }
 
-    private Predicate<Person> addCoursePredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+    private void addCoursePredicate(ArgumentMultimap argMultimap, PredicateStringPair psp) {
         String courseArgs = argMultimap.getValue(PREFIX_COURSE).orElse("").trim();
         if (!courseArgs.isEmpty()) {
             String[] courseKeywords = courseArgs.split("\\s+");
             Predicate<Person> coursePredicate = new CourseContainsKeywordsPredicate(Arrays.asList(courseKeywords));
-            combinedPredicate = combinedPredicate.and(coursePredicate);
+            psp.appendString(coursePredicate.toString());
+            psp.combinePredicate(coursePredicate);
         }
-        return combinedPredicate;
     }
 
-    private Predicate<Person> addModulePredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+    private void addModulePredicate(ArgumentMultimap argMultimap, PredicateStringPair psp) {
         String moduleArgs = argMultimap.getValue(PREFIX_MOD).orElse("").trim();
         if (!moduleArgs.isEmpty()) {
             String[] moduleKeywords = moduleArgs.split("\\s+");
             Predicate<Person> modulePredicate = new ModuleContainsKeywordsPredicate(Arrays.asList(moduleKeywords));
-            combinedPredicate = combinedPredicate.and(modulePredicate);
+            psp.appendString(modulePredicate.toString());
+            psp.combinePredicate(modulePredicate);
         }
-        return combinedPredicate;
     }
 
-    private Predicate<Person> addSkillPredicate(ArgumentMultimap argMultimap, Predicate<Person> combinedPredicate) {
+    private void addSkillPredicate(ArgumentMultimap argMultimap, PredicateStringPair psp) {
         String skillArgs = argMultimap.getValue(PREFIX_SKILL).orElse("").trim();
         if (!skillArgs.isEmpty()) {
             String[] skillKeywords = skillArgs.split("\\s+");
             Predicate<Person> skillPredicate = new SkillContainsKeywordsPredicate(Arrays.asList(skillKeywords));
-            combinedPredicate = combinedPredicate.and(skillPredicate);
+            psp.appendString(skillPredicate.toString());
+            psp.combinePredicate(skillPredicate);
         }
-        return combinedPredicate;
     }
 
 }

--- a/src/main/java/codoc/model/Model.java
+++ b/src/main/java/codoc/model/Model.java
@@ -83,7 +83,7 @@ public interface Model {
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredPersonList(Predicate<Person> predicate);
+    String updateFilteredPersonList(Predicate<Person> predicate, String userInput);
 
     Person getProtagonist();
 

--- a/src/main/java/codoc/model/ModelManager.java
+++ b/src/main/java/codoc/model/ModelManager.java
@@ -27,6 +27,7 @@ public class ModelManager implements Model {
     private Person protagonist;
     private String currentTab;
     private final ArrayList<Predicate<Person>> predicateArrayList = new ArrayList<>();
+    private String userInputs = "";
 
     /**
      * Initializes a ModelManager with the given codoc and userPrefs.
@@ -113,7 +114,7 @@ public class ModelManager implements Model {
     @Override
     public void addPerson(Person person) {
         codoc.addPerson(person);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS, "");
     }
 
     @Override
@@ -135,15 +136,19 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredPersonList(Predicate<Person> predicate) {
+    public String updateFilteredPersonList(Predicate<Person> predicate, String userInput) {
         if (predicate == PREDICATE_SHOW_ALL_PERSONS) {
             predicateArrayList.clear();
+            userInputs = "";
         }
         requireNonNull(predicate);
         predicateArrayList.add(predicate);
+        userInputs += " " + userInput + "\n";
         Predicate<Person> combinePredicate = predicateArrayList.stream().reduce(person -> true, Predicate::and);
-        logger.log(Level.INFO, "Number of predicates = " + predicateArrayList.size());
+        //logger.log(Level.INFO, "Number of predicates = " + predicateArrayList.size());
+        logger.log(Level.INFO, "Number of predicates = " + userInputs);
         filteredPersons.setPredicate(combinePredicate);
+        return userInputs;
     }
 
     //=========== Protagonist ================================================================================

--- a/src/main/java/codoc/model/ModelManager.java
+++ b/src/main/java/codoc/model/ModelManager.java
@@ -27,7 +27,7 @@ public class ModelManager implements Model {
     private Person protagonist;
     private String currentTab;
     private final ArrayList<Predicate<Person>> predicateArrayList = new ArrayList<>();
-    private String userInputs = "";
+    private String appliedPredicates = "";
 
     /**
      * Initializes a ModelManager with the given codoc and userPrefs.
@@ -137,17 +137,19 @@ public class ModelManager implements Model {
 
     @Override
     public String updateFilteredPersonList(Predicate<Person> predicate, String userInput) {
+        requireNonNull(predicate);
         if (predicate == PREDICATE_SHOW_ALL_PERSONS) {
             predicateArrayList.clear();
-            userInputs = "";
+            appliedPredicates = "";
         }
-        requireNonNull(predicate);
-        predicateArrayList.add(predicate);
-        userInputs = userInput + "\n" + userInputs;
+        if (!userInput.equals("")) {
+            predicateArrayList.add(predicate);
+            appliedPredicates = userInput + "\n" + appliedPredicates;
+        }
         Predicate<Person> combinePredicate = predicateArrayList.stream().reduce(person -> true, Predicate::and);
-        logger.log(Level.INFO, "Number of predicates = " + predicateArrayList.size());
         filteredPersons.setPredicate(combinePredicate);
-        return "> " + userInputs.trim();
+        logger.log(Level.INFO, "Number of predicates = " + predicateArrayList.size());
+        return "> " + appliedPredicates.trim();
     }
 
     //=========== Protagonist ================================================================================

--- a/src/main/java/codoc/model/ModelManager.java
+++ b/src/main/java/codoc/model/ModelManager.java
@@ -143,12 +143,11 @@ public class ModelManager implements Model {
         }
         requireNonNull(predicate);
         predicateArrayList.add(predicate);
-        userInputs += " " + userInput + "\n";
+        userInputs = userInput + "\n" + userInputs;
         Predicate<Person> combinePredicate = predicateArrayList.stream().reduce(person -> true, Predicate::and);
-        //logger.log(Level.INFO, "Number of predicates = " + predicateArrayList.size());
-        logger.log(Level.INFO, "Number of predicates = " + userInputs);
+        logger.log(Level.INFO, "Number of predicates = " + predicateArrayList.size());
         filteredPersons.setPredicate(combinePredicate);
-        return userInputs;
+        return "> " + userInputs.trim();
     }
 
     //=========== Protagonist ================================================================================

--- a/src/main/java/codoc/model/module/ModuleContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/module/ModuleContainsKeywordsPredicate.java
@@ -1,7 +1,6 @@
 package codoc.model.module;
 
 import static codoc.logic.parser.CliSyntax.PREFIX_MOD;
-import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.List;
 import java.util.function.Predicate;

--- a/src/main/java/codoc/model/module/ModuleContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/module/ModuleContainsKeywordsPredicate.java
@@ -1,5 +1,8 @@
 package codoc.model.module;
 
+import static codoc.logic.parser.CliSyntax.PREFIX_MOD;
+import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -54,5 +57,9 @@ public class ModuleContainsKeywordsPredicate implements Predicate<Person> {
         return other == this // short circuit if same object
                 || (other instanceof ModuleContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((ModuleContainsKeywordsPredicate) other).keywords)); // state check
+    }
+    @Override
+    public String toString() {
+        return PREFIX_MOD + keywords.stream().reduce("", String::concat);
     }
 }

--- a/src/main/java/codoc/model/person/CourseContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/CourseContainsKeywordsPredicate.java
@@ -1,5 +1,8 @@
 package codoc.model.person;
 
+import static codoc.logic.parser.CliSyntax.PREFIX_COURSE;
+import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -24,6 +27,10 @@ public class CourseContainsKeywordsPredicate implements Predicate<Person> {
         return other == this // short circuit if same object
                 || (other instanceof CourseContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((CourseContainsKeywordsPredicate) other).keywords)); // state check
+    }
+    @Override
+    public String toString() {
+        return PREFIX_COURSE + keywords.stream().reduce("", String::concat);
     }
 
 }

--- a/src/main/java/codoc/model/person/CourseContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/CourseContainsKeywordsPredicate.java
@@ -1,7 +1,6 @@
 package codoc.model.person;
 
 import static codoc.logic.parser.CliSyntax.PREFIX_COURSE;
-import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.List;
 import java.util.function.Predicate;

--- a/src/main/java/codoc/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/NameContainsKeywordsPredicate.java
@@ -1,5 +1,7 @@
 package codoc.model.person;
 
+import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -24,6 +26,10 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         return other == this // short circuit if same object
                 || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
+    }
+    @Override
+    public String toString() {
+        return PREFIX_NAME + keywords.stream().reduce("", String::concat);
     }
 
 }

--- a/src/main/java/codoc/model/person/YearContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/YearContainsKeywordsPredicate.java
@@ -1,5 +1,8 @@
 package codoc.model.person;
 
+import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
+import static codoc.logic.parser.CliSyntax.PREFIX_YEAR;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -24,6 +27,10 @@ public class YearContainsKeywordsPredicate implements Predicate<Person> {
         return other == this // short circuit if same object
                 || (other instanceof YearContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((YearContainsKeywordsPredicate) other).keywords)); // state check
+    }
+    @Override
+    public String toString() {
+        return PREFIX_YEAR + keywords.stream().reduce("", String::concat);
     }
 
 }

--- a/src/main/java/codoc/model/person/YearContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/person/YearContainsKeywordsPredicate.java
@@ -1,6 +1,5 @@
 package codoc.model.person;
 
-import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
 import static codoc.logic.parser.CliSyntax.PREFIX_YEAR;
 
 import java.util.List;

--- a/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
@@ -1,5 +1,8 @@
 package codoc.model.skill;
 
+import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
+import static codoc.logic.parser.CliSyntax.PREFIX_SKILL;
+
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -36,6 +39,11 @@ public class SkillContainsKeywordsPredicate implements Predicate<Person> {
         return other == this // short circuit if same object
                 || (other instanceof SkillContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((SkillContainsKeywordsPredicate) other).keywords)); // state check
+    }
+
+    @Override
+    public String toString() {
+        return PREFIX_SKILL + keywords.stream().reduce("", String::concat);
     }
 }
 

--- a/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
@@ -1,6 +1,5 @@
 package codoc.model.skill;
 
-import static codoc.logic.parser.CliSyntax.PREFIX_NAME;
 import static codoc.logic.parser.CliSyntax.PREFIX_SKILL;
 
 import java.util.List;

--- a/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
+++ b/src/main/java/codoc/model/skill/SkillContainsKeywordsPredicate.java
@@ -19,7 +19,7 @@ public class SkillContainsKeywordsPredicate implements Predicate<Person> {
 
     private boolean doesNotContain(String skillUserIsSearchingFor, Person person) {
         return person.getSkills().stream().noneMatch(
-                skill -> skill.skillName.equalsIgnoreCase(skillUserIsSearchingFor));
+                skill -> skill.skillName.toUpperCase().contains(skillUserIsSearchingFor.toUpperCase()));
     }
 
     @Override

--- a/src/test/java/codoc/logic/commands/AddCommandTest.java
+++ b/src/test/java/codoc/logic/commands/AddCommandTest.java
@@ -144,7 +144,7 @@ public class AddCommandTest {
         }
 
         @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
+        public String updateFilteredPersonList(Predicate<Person> predicate, String userInputs) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/codoc/logic/commands/CommandTestUtil.java
+++ b/src/test/java/codoc/logic/commands/CommandTestUtil.java
@@ -157,7 +157,8 @@ public class CommandTestUtil {
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(splitName[0]));
+        model.updateFilteredPersonList(namePredicate, namePredicate.toString());
 
         assertEquals(1, model.getFilteredPersonList().size());
     }

--- a/src/test/java/codoc/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/codoc/logic/commands/DeleteCommandTest.java
@@ -98,7 +98,7 @@ public class DeleteCommandTest {
      * Updates {@code model}'s filtered list to show no one.
      */
     private void showNoPerson(Model model) {
-        model.updateFilteredPersonList(p -> false);
+        model.updateFilteredPersonList(p -> false, "show no person");
 
         assertTrue(model.getFilteredPersonList().isEmpty());
     }

--- a/src/test/java/codoc/logic/commands/FindCommandTest.java
+++ b/src/test/java/codoc/logic/commands/FindCommandTest.java
@@ -28,14 +28,14 @@ public class FindCommandTest {
         NameContainsKeywordsPredicate secondPredicate =
                 new NameContainsKeywordsPredicate(Collections.singletonList("second"));
 
-        FindCommand findFirstCommand = new FindCommand(firstPredicate);
-        FindCommand findSecondCommand = new FindCommand(secondPredicate);
+        FindCommand findFirstCommand = new FindCommand(firstPredicate, firstPredicate.toString());
+        FindCommand findSecondCommand = new FindCommand(secondPredicate, secondPredicate.toString());
 
         // same object -> returns true
         assertTrue(findFirstCommand.equals(findFirstCommand));
 
         // same values -> returns true
-        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate);
+        FindCommand findFirstCommandCopy = new FindCommand(firstPredicate, firstPredicate.toString());
         assertTrue(findFirstCommand.equals(findFirstCommandCopy));
 
         // different types -> returns false

--- a/src/test/java/codoc/model/ModelManagerTest.java
+++ b/src/test/java/codoc/model/ModelManagerTest.java
@@ -118,11 +118,12 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        NameContainsKeywordsPredicate namePredicate = new NameContainsKeywordsPredicate(Arrays.asList(keywords));
+        modelManager.updateFilteredPersonList(namePredicate, namePredicate.toString());
         assertFalse(modelManager.equals(new ModelManager(codoc, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
-        modelManager.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+        modelManager.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS, "");
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();

--- a/src/test/java/codoc/model/skill/SkillContainsKeywordsPredicateTest.java
+++ b/src/test/java/codoc/model/skill/SkillContainsKeywordsPredicateTest.java
@@ -20,16 +20,17 @@ public class SkillContainsKeywordsPredicateTest {
         // Multiple skill where all match
         predicate = new SkillContainsKeywordsPredicate(List.of("PyTHON", "jAvA"));
         assertTrue(predicate.test(new PersonBuilder().withSkills("JaVa", "PYTHON").build()));
+
+        // Single skill that partially match
+        predicate = new SkillContainsKeywordsPredicate(List.of("jAvA"));
+        assertTrue(predicate.test(new PersonBuilder().withSkills("JaVaScript").build()));
+
     }
 
     @Test
     public void test_keywords_returnsFalse() {
-        // Single skill that does not match
-        SkillContainsKeywordsPredicate predicate = new SkillContainsKeywordsPredicate(List.of("jAvA"));
-        assertFalse(predicate.test(new PersonBuilder().withSkills("JaVaScript").build()));
-
         // Multiple skill where at least one has no match
-        predicate = new SkillContainsKeywordsPredicate(List.of("PyTHON", "JaVaScript"));
+        SkillContainsKeywordsPredicate predicate = new SkillContainsKeywordsPredicate(List.of("PyTHON", "JaVaScript"));
         assertFalse(predicate.test(new PersonBuilder().withSkills("JaVa", "PYTHON").build()));
     }
 }


### PR DESCRIPTION
Show all the inputs used for filtering. Therefore, if user does `find m/00000 m/cs1101s`, only the latter will be shown due to our implementation of taking the last valid prefix.

* only `list` will reset the history
* for other commands, doing a `find m/` or any other variant where all prefix does not have any parameter will show the find history.  Will try to come up with a better way for this.
* the one after the prompt `>` is the latest 
* history is ordered from latest to oldest
* A simple enhancement would be to remove the latest find attempt independently but may clash with undo/redo feature if implemented

<img width="1154" alt="Screenshot 2023-03-25 at 3 08 55 PM" src="https://user-images.githubusercontent.com/86219547/227703049-c1401c55-0e8b-4137-b6a3-1a0552ff4f2b.png">