### PR TITLE
Add wrap text to result display

### DIFF
--- a/src/main/java/codoc/ui/ResultDisplay.java
+++ b/src/main/java/codoc/ui/ResultDisplay.java
@@ -16,8 +16,12 @@ public class ResultDisplay extends UiPart<Region> {
     @FXML
     private TextArea resultDisplay;
 
+    /**
+     * Creates a {@code ResultDisplay} with wrap text set to true.
+     */
     public ResultDisplay() {
         super(FXML);
+        resultDisplay.setWrapText(true);
     }
 
     public void setFeedbackToUser(String feedbackToUser) {


### PR DESCRIPTION
Just a simple UI tweak

# With wrap text
<img width="610" alt="Screenshot 2023-03-25 at 3 43 50 PM" src="https://user-images.githubusercontent.com/86219547/227704500-1af93477-19e1-4f56-a293-784b4b3ff630.png">

# Without wrap text
<img width="605" alt="Screenshot 2023-03-25 at 3 41 03 PM" src="https://user-images.githubusercontent.com/86219547/227704503-33479e33-e588-44bb-aeda-bfc9ff09bc32.png">
