### PR TITLE
empty person list display protagonist bug

### DIFF
--- a/src/main/java/codoc/logic/commands/AddCommand.java
+++ b/src/main/java/codoc/logic/commands/AddCommand.java
@@ -35,6 +35,7 @@ public class AddCommand extends Command {
             + PREFIX_NAME + "John Doe "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_COURSE + "1 "
+            + PREFIX_YEAR + "2 "
             + PREFIX_GITHUB + "j0hn-Do3 "
             + PREFIX_LINKEDIN + "linkedin.com/in/j0hn-Do3 "
             + PREFIX_SKILL + "python "
@@ -62,8 +63,11 @@ public class AddCommand extends Command {
         if (model.hasPerson(toAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
-
+        if (model.getFilteredPersonList().size() == 0) {
+            model.setProtagonist(toAdd);
+        }
         model.addPerson(toAdd);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd));
     }
 

--- a/src/main/java/codoc/logic/commands/DeleteCommand.java
+++ b/src/main/java/codoc/logic/commands/DeleteCommand.java
@@ -40,6 +40,14 @@ public class DeleteCommand extends Command {
         }
 
         Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+
+        if (lastShownList.size() == 1) {
+            model.setProtagonist(Person.getDummyPerson());
+        } else if (personToDelete.equals(model.getProtagonist()) && lastShownList.size() == targetIndex.getOneBased()) {
+            model.setProtagonist(lastShownList.get(targetIndex.getZeroBased() - 1));
+        } else if (personToDelete.equals(model.getProtagonist())) {
+            model.setProtagonist(lastShownList.get(targetIndex.getZeroBased() + 1));
+        }
         model.deletePerson(personToDelete);
         return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
     }

--- a/src/main/java/codoc/model/ModelManager.java
+++ b/src/main/java/codoc/model/ModelManager.java
@@ -41,12 +41,11 @@ public class ModelManager implements Model {
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.codoc.getPersonList());
         if (filteredPersons.size() == 0) { // fresh database
-            protagonist = null;
-            currentTab = null;
+            protagonist = Person.getDummyPerson();
         } else {
             protagonist = filteredPersons.get(0);
-            currentTab = "c";
         }
+        currentTab = "c";
     }
 
     public ModelManager() {

--- a/src/main/java/codoc/model/course/CourseList.java
+++ b/src/main/java/codoc/model/course/CourseList.java
@@ -9,11 +9,19 @@ import java.util.Arrays;
 public class CourseList {
     public static final ArrayList<String> COURSE_LIST = new ArrayList<>(
             Arrays.asList(
-                    "Computer Science",
+                    "Accounting",
+                    "Architecture",
+                    "Business Administration",
                     "Business Analytics",
+                    "Computer Engineering",
+                    "Computer Science",
+                    "Economics",
+                    "Geography",
                     "Information Systems",
                     "Information Security",
-                    "Computer Engineering"
+                    "Life Sciences",
+                    "Pharmaceutical Science",
+                    "Physics"
             )
     );
 

--- a/src/main/java/codoc/model/person/Person.java
+++ b/src/main/java/codoc/model/person/Person.java
@@ -15,6 +15,7 @@ import codoc.model.skill.Skill;
  * Represents a Person in CoDoc. Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Person {
+    private static final Person dummyPerson = createDummy();
 
     // Identity fields
     private final ProfilePicture profilePicture;
@@ -55,7 +56,22 @@ public class Person {
         this.skills.addAll(skills);
         this.modules.addAll(modules);
     }
+    public static Person getDummyPerson() {
+        return dummyPerson;
+    }
 
+    private static Person createDummy() {
+        ProfilePicture profilePicture = new ProfilePicture("src/main/resources/images/avataricons/001-bear.png");
+        Name name = new Name("DEFAULT NAME");
+        Course course = new Course("1");
+        Year year = new Year("1");
+        Github github = new Github("default-github");
+        Email email = new Email("default_email@gmail.com");
+        Linkedin linkedin = new Linkedin("linkedin.com/in/default-linkedin");
+        Set<Skill> skills = new HashSet<>();
+        Set<Module> mods = new HashSet<>();
+        return new Person(profilePicture, name, course, year, github, email, linkedin, skills, mods);
+    }
     public ProfilePicture getProfilePicture() {
         return profilePicture;
     }

--- a/src/main/java/codoc/ui/HelpWindow.java
+++ b/src/main/java/codoc/ui/HelpWindow.java
@@ -50,7 +50,7 @@ public class HelpWindow extends UiPart<Stage> {
     @FXML
     private final CommandExample[] examples = {
         new CommandExample("Add", "add n/Bob Sim y/2 c/1 e/e0823741@nus.edu g/bobabob "
-                + "l/linkedin.com/in/bom-sim-086g93847 m/AY2223S2 CS2103T m/AY2223S2 CS2101 s/python s/java"),
+                + "l/linkedin.com/in/bom-sim-086g93847 m/ay2223s2 CS2103T m/AY2223S2 cs2101 s/python s/java"),
         new CommandExample("View contact", "view 3"),
         new CommandExample("View tab", "view c, view m, view s"),
         new CommandExample("Edit contact in the right panel", "edit n/David m+/AY2223S2 CS2109S s-/python"),

--- a/src/test/data/JsonSerializableCodocTest/typicalPersonsCodoc.json
+++ b/src/test/data/JsonSerializableCodocTest/typicalPersonsCodoc.json
@@ -3,7 +3,7 @@
   "persons" : [ {
     "profilePicturePath" : "src/main/resources/images/avataricons/001-bear.png",
     "name" : "Alice Pauline",
-    "course": "Computer Science",
+    "course": "Accounting",
     "year": "1",
     "github" : "alice-Pauline",
     "email" : "alice@example.com",
@@ -13,7 +13,7 @@
   }, {
     "profilePicturePath" : "src/main/resources/images/avataricons/002-rabbit.png",
     "name" : "Benson Meier",
-    "course": "Computer Science",
+    "course": "Accounting",
     "year": "1",
     "github" : "bensonmeier",
     "email" : "johnd@example.com",
@@ -23,7 +23,7 @@
   }, {
     "profilePicturePath" : "src/main/resources/images/avataricons/003-panda.png",
     "name" : "Carl Kurz",
-    "course": "Computer Science",
+    "course": "Accounting",
     "year": "1",
     "github" : "Carl-Kurz",
     "email" : "heinz@example.com",
@@ -33,7 +33,7 @@
   }, {
     "profilePicturePath" : "src/main/resources/images/avataricons/004-sloth.png",
     "name" : "Daniel Meier",
-    "course": "Computer Science",
+    "course": "Accounting",
     "year": "1",
     "github" : "d4nielMeier",
     "email" : "cornelia@example.com",
@@ -43,7 +43,7 @@
   }, {
     "profilePicturePath" : "src/main/resources/images/avataricons/005-hen.png",
     "name" : "Elle Meyer",
-    "course": "Computer Science",
+    "course": "Accounting",
     "year": "1",
     "github" : "Elle-meyer",
     "email" : "werner@example.com",
@@ -53,7 +53,7 @@
   }, {
     "profilePicturePath" : "src/main/resources/images/avataricons/006-puffer-fish.png",
     "name" : "Fiona Kunz",
-    "course": "Computer Science",
+    "course": "Accounting",
     "year": "1",
     "github" : "F1onaKunz",
     "email" : "lydia@example.com",
@@ -63,7 +63,7 @@
   }, {
     "profilePicturePath" : "src/main/resources/images/avataricons/007-beaver.png",
     "name" : "George Best",
-    "course": "Computer Science",
+    "course": "Accounting",
     "year": "1",
     "github" : "george-b3st",
     "email" : "anna@example.com",

--- a/src/test/java/codoc/logic/commands/AddCommandTest.java
+++ b/src/test/java/codoc/logic/commands/AddCommandTest.java
@@ -20,8 +20,10 @@ import codoc.model.Model;
 import codoc.model.ReadOnlyCodoc;
 import codoc.model.ReadOnlyUserPrefs;
 import codoc.model.person.Person;
+import codoc.model.person.UniquePersonList;
 import codoc.testutil.PersonBuilder;
 import javafx.collections.ObservableList;
+import javafx.collections.transformation.FilteredList;
 
 public class AddCommandTest {
 
@@ -192,7 +194,13 @@ public class AddCommandTest {
      */
     private class ModelStubAcceptingPersonAdded extends ModelStub {
         final ArrayList<Person> personsAdded = new ArrayList<>();
+        private final UniquePersonList uniquePersonList = new UniquePersonList();
+        private final FilteredList<Person> filteredPersons =
+                new FilteredList<>(uniquePersonList.asUnmodifiableObservableList());
 
+        public ModelStubAcceptingPersonAdded() {
+            uniquePersonList.add(Person.getDummyPerson());
+        }
         @Override
         public boolean hasPerson(Person person) {
             requireNonNull(person);
@@ -203,6 +211,10 @@ public class AddCommandTest {
         public void addPerson(Person person) {
             requireNonNull(person);
             personsAdded.add(person);
+        }
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return filteredPersons;
         }
 
         @Override


### PR DESCRIPTION
Made minor edits to the help window and added more courses.

During delete command, if the person in view was the one to be deleted, the right panel would still display the already-deleted person after the execution of the command.

Hence, this weird behavior would introduce a bug that would allow user to make edits to the already deleted person.

Another bug discovered in the process occurred when the app has an empty person list. The result would be a null pointer error in the right panel and after adding a new person, we will not be able to view the new person.

![image](https://user-images.githubusercontent.com/65301406/227715693-7d5a3d2c-7ab1-4a26-b39d-14dd9466dc83.png)

I attempted to rectify this by calling `setProtagonist()` for the next person in the list. If the deleted person happens to be the last person of the list, the protagonist would be set to the new last person of the new list.

If the application ever encounters an empty person list, the right panel now displays a default person, which is a singleton, instead of displaying `Label` and `detailed information`. This helps the application maintain consistency when dealing with `setProtagonist()` if the deleted person is the only person in the list.