### PR TITLE
Remove ListView prefHeight calculation

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -869,41 +869,6 @@ by a person that is created as a ListView, similar to the [PersonListPanel](#per
 
 <br>
 
-#### Design considerations
-
-The ListView for list of modules are implemented in a similar manner to the one for [PersonListPanel](#personlistpanel).
-One major difference lies in the `prefHeight` attribute of the ListView set by the controller.
-
-The list of modules may grow or shrink as the program executes. Users may scroll down this list if it is unable to
-display all of its contents. However, we wanted to minimize GUI interaction since our primary users prefer a CLI. One
-could set the `VBox.vgrow` attribute of the container to "ALWAYS" and expand the table, but without limiting the
-`maxHeight` or `prefHeight` attribute for the ListView, it would grow all the way to the bottom of the panel showing
-too much of empty space in the ListView, negatively affecting its visuals.
-
-To get around this and make the height grow just enough to display all items in the list, controller will calculate
-the optimal height based on the number of entries and set it as the `prefHeight` of the ListView, minimizing the empty
-space.
-
-To let the users intuitively know that there are rooms for more modules to be added, ListView's `minHeight` has been set
-to `340` to reveal small amount of empty space. If the program window is resized too short, the ListView becomes a
-scrollable one.
-
-| ListView with long list of modules                                    | ListView with short list of modules                                    | ListView with list extending beyond window                                                   |
-|-----------------------------------------------------------------------|:-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------|
-| ![ui-listview-longlist](images/ui-diagrams/ui-listview-longlist.PNG)  | ![ui-listview-shortlist](images/ui-diagrams/ui-listview-shortlist.PNG) | ![ui-listview-longlist-shortwindow](images/ui-diagrams/ui-listview-longlist-shortwindow.PNG) |
-
-
-Here is a code snippet in `DetailedModule.java` responsible for this calculation:
-
-```java
-moduleListView.setPrefHeight((52 * modules.size()) + 2);
-```
-Note that value 52 is used because each ModuleListCard has a height of 50, with top and bottom borders of thickness 1.
-The addition of 2 at the back is a buffer. As you can tell, the values are hard coded and should be changed to take
-reference off the ModuleListCard directly, which would be fixed in upcoming updates.
-
-<br>
-
 ### **DetailedSkill**
 
 Controller class for Info Panel which holds detailed skill information about a person. Shows a list of skills possessed

--- a/src/main/java/codoc/ui/MainWindow.java
+++ b/src/main/java/codoc/ui/MainWindow.java
@@ -37,8 +37,8 @@ public class MainWindow extends UiPart<Stage> {
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
     private InfoTab infoTab;
-
     private CourseListPanel courseListPanel;
+    private ClickListener clickListener;
 
     @FXML
     private StackPane commandBoxPlaceholder;
@@ -70,6 +70,8 @@ public class MainWindow extends UiPart<Stage> {
         // Set dependencies
         this.primaryStage = primaryStage;
         this.logic = logic;
+        this.clickListener = new ClickListener();
+        clickListener.setListener(this);
 
         // Configure the UI
         setWindowDefaultSize(logic.getGuiSettings());
@@ -123,6 +125,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personListPanel = new PersonListPanel(this);
+        personListPanel.setClickListener(clickListener);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
@@ -134,7 +137,8 @@ public class MainWindow extends UiPart<Stage> {
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
-        infoTab = new InfoTab(this);
+        infoTab = new InfoTab(logic.getProtagonist(), logic.getCurrentTab());
+        infoTab.setClickListener(clickListener);
         infoTabPlaceholder.getChildren().add(infoTab.getRoot());
 
         courseListPanel = new CourseListPanel();
@@ -199,7 +203,8 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
-            infoTab = new InfoTab(this);
+            infoTab = new InfoTab(logic.getProtagonist(), logic.getCurrentTab());
+            infoTab.setClickListener(this.clickListener);
             infoTabPlaceholder.getChildren().set(0, infoTab.getRoot());
 
             if (commandResult.isShowHelp()) {
@@ -218,7 +223,42 @@ public class MainWindow extends UiPart<Stage> {
         }
     }
 
-    public void clickExecuteCommand(String commandText) throws CommandException, ParseException {
-        executeCommand(commandText);
+    /**
+     * MainWindow's own listener class that listens to click events from Ui components.
+     */
+    public class ClickListener implements UiEventListener<MainWindow> {
+
+        private MainWindow listener;
+
+        @Override
+        public void setListener(MainWindow mainWindow) {
+            this.listener = mainWindow;
+        }
+
+        @Override
+        public MainWindow getListener() {
+            if (this.listener == null) {
+                throw new RuntimeException("Error: Listener not assigned!");
+            }
+            return listener;
+        }
+
+        public void viewContact() throws CommandException, ParseException {
+            executeCommand("view c");
+        }
+
+        public void viewModule() throws CommandException, ParseException {
+            executeCommand("view m");
+        }
+
+        public void viewSkill() throws CommandException, ParseException {
+            executeCommand("view s");
+        }
+
+        public void viewIndex(String index) throws CommandException, ParseException {
+            executeCommand("view " + index);
+        }
+
     }
+
 }

--- a/src/main/java/codoc/ui/PersonCard.java
+++ b/src/main/java/codoc/ui/PersonCard.java
@@ -42,16 +42,14 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private Label email;
 
-    private MainWindow mainWindow;
-
     private int displayedIndex;
+    private MainWindow.ClickListener clickListener;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public PersonCard(MainWindow mainWindow, Person person, int displayedIndex) {
+    public PersonCard(Person person, int displayedIndex) {
         super(FXML);
-        this.mainWindow = mainWindow;
         this.person = person;
         this.displayedIndex = displayedIndex;
         id.setText(displayedIndex + "");
@@ -64,10 +62,16 @@ public class PersonCard extends UiPart<Region> {
         email.setText(person.getEmail().value);
     }
 
+    public void setClickListener(MainWindow.ClickListener listener) {
+        this.clickListener = listener;
+    }
+
     @FXML
     private void viewPerson() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view " + displayedIndex);
+        String index = id.getText();
+        clickListener.viewIndex(index);
     }
+
 
     @Override
     public boolean equals(Object other) {

--- a/src/main/java/codoc/ui/PersonListPanel.java
+++ b/src/main/java/codoc/ui/PersonListPanel.java
@@ -16,6 +16,7 @@ import javafx.scene.layout.Region;
 public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
+    private MainWindow.ClickListener clickListener;
 
     @FXML
     private ListView<Person> personListView;
@@ -27,26 +28,21 @@ public class PersonListPanel extends UiPart<Region> {
         super(FXML);
         ObservableList<Person> personList = mainWindow.getLogic().getFilteredPersonList();
         personListView.setItems(personList);
-        personListView.setCellFactory(listView -> new PersonListViewCell(mainWindow));
-        personListView.setSelectionModel(null);
-        personListView.setOnMousePressed(event -> {
-            try {
-                int index = personListView.getSelectionModel().getSelectedIndex();
-                // do something with selected person
-            } catch (NullPointerException e) {
-                // do nothing
-            }
-        });
+        personListView.setCellFactory(listView -> new PersonListViewCell());
+    }
+
+    /**
+     * Set UiEventListener for InfoTab.
+     * @param listener
+     */
+    public void setClickListener(MainWindow.ClickListener listener) {
+        this.clickListener = listener;
     }
 
     /**
      * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {
-        private MainWindow mainWindow;
-        public PersonListViewCell(MainWindow mainWindow) {
-            this.mainWindow = mainWindow;
-        }
 
         @Override
         protected void updateItem(Person person, boolean empty) {
@@ -56,7 +52,9 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(mainWindow, person, getIndex() + 1).getRoot());
+                PersonCard item = new PersonCard(person, getIndex() + 1);
+                item.setClickListener(clickListener);
+                setGraphic(item.getRoot());
             }
         }
     }

--- a/src/main/java/codoc/ui/UiEventListener.java
+++ b/src/main/java/codoc/ui/UiEventListener.java
@@ -1,0 +1,11 @@
+package codoc.ui;
+
+/**
+ * Listener used by Ui components to handle events outside commands.
+ */
+public interface UiEventListener<T> {
+
+    void setListener(T listener);
+    T getListener();
+
+}

--- a/src/main/java/codoc/ui/infopanel/DetailedContact.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedContact.java
@@ -1,9 +1,6 @@
 package codoc.ui.infopanel;
 
-import codoc.logic.commands.exceptions.CommandException;
-import codoc.logic.parser.exceptions.ParseException;
 import codoc.model.person.Person;
-import codoc.ui.MainWindow;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 
@@ -23,33 +20,18 @@ public class DetailedContact extends DetailedInfo {
     @FXML
     private Label linkedin;
 
-    private MainWindow mainWindow;
+    private Person protagonist;
 
     /**
      * Creates a {@code DetailedContact} tab with the given {@code protagonist}.
      */
-    public DetailedContact(MainWindow mainWindow) {
+    public DetailedContact(Person protagonist) {
         super(FXML);
-        this.mainWindow = mainWindow;
-        Person protagonist = mainWindow.getLogic().getProtagonist();
+        this.protagonist = protagonist;
+        github.setText(protagonist.getGithub().value);
         email.setText(protagonist.getEmail().value);
         github.setText(protagonist.getGithub().value == null ? "Not Added" : "@" + protagonist.getGithub().value);
         linkedin.setText(protagonist.getLinkedin().value == null ? "Not Added" : protagonist.getLinkedin().value);
-    }
-
-    @FXML
-    private void viewContactTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view c");
-    }
-
-    @FXML
-    private void viewModulesTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view m");
-    }
-
-    @FXML
-    private void viewSkillsTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view s");
     }
 
 }

--- a/src/main/java/codoc/ui/infopanel/DetailedInfo.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedInfo.java
@@ -1,6 +1,11 @@
 package codoc.ui.infopanel;
 
+import codoc.logic.commands.exceptions.CommandException;
+import codoc.logic.parser.exceptions.ParseException;
+import codoc.model.person.Person;
+import codoc.ui.MainWindow;
 import codoc.ui.UiPart;
+import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
 
 /**
@@ -8,11 +13,33 @@ import javafx.scene.layout.Region;
  */
 public abstract class DetailedInfo extends UiPart<Region> {
 
+    private Person protagonist;
+    private MainWindow.ClickListener listener;
+
     /**
      * Creates a {@code DetailedInfoPanel} with the given {@code fxmlFileUrl}.
      */
     public DetailedInfo(String fxmlFileUrl) {
         super(fxmlFileUrl);
+    }
+
+    public void setListener(MainWindow.ClickListener listener) {
+        this.listener = listener;
+    }
+
+    @FXML
+    private void viewContactTab() throws CommandException, ParseException {
+        listener.viewContact();
+    }
+
+    @FXML
+    private void viewModulesTab() throws CommandException, ParseException {
+        listener.viewModule();
+    }
+
+    @FXML
+    private void viewSkillsTab() throws CommandException, ParseException {
+        listener.viewSkill();
     }
 
 }

--- a/src/main/java/codoc/ui/infopanel/DetailedModule.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedModule.java
@@ -2,11 +2,8 @@ package codoc.ui.infopanel;
 
 import java.util.Comparator;
 
-import codoc.logic.commands.exceptions.CommandException;
-import codoc.logic.parser.exceptions.ParseException;
 import codoc.model.module.Module;
 import codoc.model.person.Person;
-import codoc.ui.MainWindow;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -23,15 +20,14 @@ public class DetailedModule extends DetailedInfo {
     @FXML
     private ListView<Module> moduleListView;
 
-    private MainWindow mainWindow;
+    private Person protagonist;
 
     /**
      * Creates a {@code DetailedModule} tab with the given {@code protagonist}.
      */
-    public DetailedModule(MainWindow mainWindow) {
+    public DetailedModule(Person protagonist) {
         super(FXML);
-        this.mainWindow = mainWindow;
-        Person protagonist = mainWindow.getLogic().getProtagonist();
+        this.protagonist = protagonist;
         ObservableList<Module> modules = FXCollections.observableArrayList();
         protagonist.getModules().stream()
                 .sorted(Comparator.comparing((Module module) -> module.moduleName).reversed())
@@ -40,21 +36,6 @@ public class DetailedModule extends DetailedInfo {
         moduleListView.setCellFactory(listView -> new ModuleListViewCell());
         // Took forever to get this to work but now ListView sets max height based on number of items
         moduleListView.setPrefHeight((52 * modules.size()) + 2);
-    }
-
-    @FXML
-    private void viewContactTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view c");
-    }
-
-    @FXML
-    private void viewModulesTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view m");
-    }
-
-    @FXML
-    private void viewSkillsTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view s");
     }
 
     /**

--- a/src/main/java/codoc/ui/infopanel/DetailedModule.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedModule.java
@@ -35,7 +35,7 @@ public class DetailedModule extends DetailedInfo {
         moduleListView.setItems(modules);
         moduleListView.setCellFactory(listView -> new ModuleListViewCell());
         // Took forever to get this to work but now ListView sets max height based on number of items
-        moduleListView.setPrefHeight((52 * modules.size()) + 2);
+        // moduleListView.setPrefHeight((52 * modules.size()) + 2);
     }
 
     /**

--- a/src/main/java/codoc/ui/infopanel/DetailedSkill.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedSkill.java
@@ -36,7 +36,7 @@ public class DetailedSkill extends DetailedInfo {
                 .forEach(skill -> skills.add(skill));
         skillListView.setItems(skills);
         skillListView.setCellFactory(listView -> new SkillListViewCell());
-        skillListView.setPrefHeight((52 * skills.size()) + 2);
+        // skillListView.setPrefHeight((52 * skills.size()) + 2);
     }
 
     /**

--- a/src/main/java/codoc/ui/infopanel/DetailedSkill.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedSkill.java
@@ -2,11 +2,8 @@ package codoc.ui.infopanel;
 
 import java.util.Comparator;
 
-import codoc.logic.commands.exceptions.CommandException;
-import codoc.logic.parser.exceptions.ParseException;
 import codoc.model.person.Person;
 import codoc.model.skill.Skill;
-import codoc.ui.MainWindow;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
@@ -24,16 +21,15 @@ public class DetailedSkill extends DetailedInfo {
     @FXML
     private ListView<Skill> skillListView;
 
-    private MainWindow mainWindow;
+    private Person protagonist;
 
 
     /**
      * Creates a {@code DetailedSkill} tab with the given {@code protagonist}.
      */
-    public DetailedSkill(MainWindow mainWindow) {
+    public DetailedSkill(Person protagonist) {
         super(FXML);
-        this.mainWindow = mainWindow;
-        Person protagonist = mainWindow.getLogic().getProtagonist();
+        this.protagonist = protagonist;
         ObservableList<Skill> skills = FXCollections.observableArrayList();
         protagonist.getSkills().stream()
                 .sorted(Comparator.comparing((Skill skill) -> skill.skillName))
@@ -41,21 +37,6 @@ public class DetailedSkill extends DetailedInfo {
         skillListView.setItems(skills);
         skillListView.setCellFactory(listView -> new SkillListViewCell());
         skillListView.setPrefHeight((52 * skills.size()) + 2);
-    }
-
-    @FXML
-    private void viewContactTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view c");
-    }
-
-    @FXML
-    private void viewModulesTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view m");
-    }
-
-    @FXML
-    private void viewSkillsTab() throws CommandException, ParseException {
-        mainWindow.clickExecuteCommand("view s");
     }
 
     /**

--- a/src/main/java/codoc/ui/infopanel/InfoTab.java
+++ b/src/main/java/codoc/ui/infopanel/InfoTab.java
@@ -20,6 +20,7 @@ public class InfoTab extends UiPart<Region> {
 
     private static final String FXML = "InfoTab.fxml";
     private final Logger logger = LogsCenter.getLogger(InfoTab.class);
+    private MainWindow.ClickListener clickListener;
 
     private DetailedInfo detailedInfo;
 
@@ -38,23 +39,21 @@ public class InfoTab extends UiPart<Region> {
     /**
      * Creates a {@code InfoTab} with the given {@code protagonist} and {@code tab}.
      */
-    public InfoTab(MainWindow mainWindow) {
+    public InfoTab(Person protagonist, String tab) {
 
         super(FXML);
-        Person protagonist = mainWindow.getLogic().getProtagonist();
-        String tab = mainWindow.getLogic().getCurrentTab();
         logger.info("Setting up Info Panel...");
 
         if (tab != null) {
             if (tab.equals("c")) {
                 logger.info("[Info Panel]: Creating DetailedContact...");
-                detailedInfo = new DetailedContact(mainWindow);
+                detailedInfo = new DetailedContact(protagonist);
             } else if (tab.equals("m")) {
                 logger.info("[Info Panel]: Creating DetailedModule...");
-                detailedInfo = new DetailedModule(mainWindow);
+                detailedInfo = new DetailedModule(protagonist);
             } else {
                 logger.info("[Info Panel]: Creating DetailedSkill...");
-                detailedInfo = new DetailedSkill(mainWindow);
+                detailedInfo = new DetailedSkill(protagonist);
             }
         }
 
@@ -73,6 +72,15 @@ public class InfoTab extends UiPart<Region> {
         } else {
             logger.info("[Info Panel]: Protagonist not found. Showing default placeholders");
         }
+    }
+
+    /**
+     * Set UiEventListener for InfoTab.
+     * @param listener
+     */
+    public void setClickListener(MainWindow.ClickListener listener) {
+        this.clickListener = listener;
+        detailedInfo.setListener(clickListener);
     }
 
 }

--- a/src/main/resources/view/CourseListPanel.fxml
+++ b/src/main/resources/view/CourseListPanel.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 
-<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="220.0" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="400.0" prefWidth="220.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <Label fx:id="header" alignment="TOP_CENTER" prefHeight="119.0" prefWidth="200.0" styleClass="cell_big_label">
          <minWidth>

--- a/src/main/resources/view/DetailedContact.fxml
+++ b/src/main/resources/view/DetailedContact.fxml
@@ -8,47 +8,37 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Rectangle?>
-<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/19"
-      xmlns:fx="http://javafx.com/fxml/1">
+
+<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <StackPane>
             <children>
-                <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#f0f0f0" height="30.0" strokeType="INSIDE"
-                           style="-fx-arc-height: 20; -fx-arc-width: 20;" width="300.0"/>
+                <Rectangle arcHeight="5.0" arcWidth="5.0" fill="#f0f0f0" height="30.0" strokeType="INSIDE" style="-fx-arc-height: 20; -fx-arc-width: 20;" width="300.0" />
                 <HBox alignment="CENTER">
                     <children>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0"
-                                        onAction="#viewContactTab"
-                                        style="-fx-background-color: #79addc; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;"
-                                        text="Contact">
+                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #79addc; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Contact" textAlignment="CENTER">
                                     <cursor>
-                                        <Cursor fx:constant="HAND"/>
+                                        <Cursor fx:constant="HAND" />
                                     </cursor>
                                 </Button>
                             </children>
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0"
-                                        onAction="#viewModulesTab"
-                                        style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;"
-                                        text="Modules">
+                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Modules" textAlignment="CENTER">
                                     <cursor>
-                                        <Cursor fx:constant="HAND"/>
+                                        <Cursor fx:constant="HAND" />
                                     </cursor>
                                 </Button>
                             </children>
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0"
-                                        onAction="#viewSkillsTab"
-                                        style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;"
-                                        text="Skills">
+                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Skills" textAlignment="CENTER">
                                     <cursor>
-                                        <Cursor fx:constant="HAND"/>
+                                        <Cursor fx:constant="HAND" />
                                     </cursor>
                                 </Button>
                             </children>
@@ -69,7 +59,7 @@
                 <Label fx:id="linkedin" text="\\\$linkedin_url"/>
             </children>
             <VBox.margin>
-                <Insets left="10.0" right="10.0" top="1.0"/>
+                <Insets left="10.0" right="10.0" top="1.0" />
             </VBox.margin>
         </VBox>
     </children>

--- a/src/main/resources/view/DetailedModule.fxml
+++ b/src/main/resources/view/DetailedModule.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Rectangle?>
 
-<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <StackPane VBox.vgrow="NEVER">
             <children>
@@ -18,7 +18,7 @@
                     <children>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;" text="Contact">
+                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Contact" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -27,7 +27,7 @@
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #ffc09f; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;" text="Modules">
+                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #ffc09f; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Modules" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -36,7 +36,7 @@
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;" text="Skills">
+                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Skills" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>

--- a/src/main/resources/view/DetailedSkill.fxml
+++ b/src/main/resources/view/DetailedSkill.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.shape.Rectangle?>
 
-<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <children>
       <StackPane VBox.vgrow="NEVER">
          <children>
@@ -18,7 +18,7 @@
                <children>
                   <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                      <children>
-                        <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;" text="Contact">
+                        <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Contact" textAlignment="CENTER">
                            <cursor>
                               <Cursor fx:constant="HAND" />
                            </cursor>
@@ -27,7 +27,7 @@
                   </StackPane>
                   <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                      <children>
-                        <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;" text="Modules">
+                        <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Modules" textAlignment="CENTER">
                            <cursor>
                               <Cursor fx:constant="HAND" />
                            </cursor>
@@ -36,7 +36,7 @@
                   </StackPane>
                   <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                      <children>
-                        <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #ffee93; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: black;" text="Skills">
+                        <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #ffee93; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Skills" textAlignment="CENTER">
                            <cursor>
                               <Cursor fx:constant="HAND" />
                            </cursor>

--- a/src/main/resources/view/InfoTab.fxml
+++ b/src/main/resources/view/InfoTab.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Font?>
-<VBox id="infoPane" fx:id="infoPane" alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/19"
+<VBox id="infoPane" fx:id="infoPane" alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8"
       xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <ImageView fx:id="profilePicture" fitHeight="100.0" fitWidth="100.0">

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.stage.Stage?>
 
-<fx:root minHeight="660.0" minWidth="1160.0" onCloseRequest="#handleExit" title="CoDoc" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root minHeight="660.0" minWidth="1160.0" onCloseRequest="#handleExit" title="CoDoc" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/technologist.png" />
   </icons>

--- a/src/main/resources/view/PersonCard.fxml
+++ b/src/main/resources/view/PersonCard.fxml
@@ -11,7 +11,7 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
-<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <GridPane HBox.hgrow="ALWAYS">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />


### PR DESCRIPTION
With #126, new implementation of ListView, that orders list of modules and skills, has been changed to extend to the end of the screen always.

Removed calculation step for prefHeight attribute in these ListView objects that previously restricted the height of list to only grow past a certain size.

Design considerations for them in Developer Guide has also been updated to meet the change.