### PR TITLE
Fix bug

### DIFF
--- a/src/main/java/codoc/logic/parser/ParserUtil.java
+++ b/src/main/java/codoc/logic/parser/ParserUtil.java
@@ -62,6 +62,9 @@ public class ParserUtil {
      */
     public static Github parseGithub(String github) throws ParseException {
         if (github != null) {
+            if (github.equals("")) {
+                return new Github(null);
+            }
             String trimmedGithub = github.trim();
             if (!Github.isValidGithub(trimmedGithub)) {
                 throw new ParseException(Github.MESSAGE_CONSTRAINTS);
@@ -79,6 +82,9 @@ public class ParserUtil {
      */
     public static Linkedin parseLinkedin(String linkedin) throws ParseException {
         if (linkedin != null) {
+            if (linkedin.equals("")) {
+                return new Linkedin(null);
+            }
             String trimmedLinkedin = linkedin.trim();
             if (!Linkedin.isValidLinkedin(trimmedLinkedin)) {
                 throw new ParseException(Linkedin.MESSAGE_CONSTRAINTS);

--- a/src/main/java/codoc/model/person/Github.java
+++ b/src/main/java/codoc/model/person/Github.java
@@ -48,6 +48,7 @@ public class Github {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Github // instanceof handles nulls
+                && value != null
                 && value.equals(((Github) other).value)); // state check
     }
 

--- a/src/main/java/codoc/model/person/Linkedin.java
+++ b/src/main/java/codoc/model/person/Linkedin.java
@@ -50,6 +50,7 @@ public class Linkedin {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Linkedin // instanceof handles nulls
+                && value != null
                 && value.equals(((Linkedin) other).value)); // state check
     }
 


### PR DESCRIPTION
Previously, edit g/ and edit l/ did not remove the github and linkedin of the person although it should. 

Hence, I added handling for the case where the input was an empty string.