### PR TITLE
[GUI] Auto-scroll and highlight for ViewCommand, name wrap fix, and new result message for copying URLs

### DIFF
--- a/src/main/java/codoc/logic/commands/CommandResult.java
+++ b/src/main/java/codoc/logic/commands/CommandResult.java
@@ -3,6 +3,7 @@ package codoc.logic.commands;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
+import java.util.Optional;
 
 /**
  * Represents the result of a command execution.
@@ -12,7 +13,7 @@ public class CommandResult {
     private final String feedbackToUser;
 
     /** Hidden code number to facilitate interaction with UI */
-    private int code;
+    private String code;
 
     /** Help information should be shown to the user. */
     private final boolean showHelp;
@@ -35,7 +36,7 @@ public class CommandResult {
     /**
      *
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, int code) {
+    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, String code) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
@@ -67,8 +68,8 @@ public class CommandResult {
         return feedbackToUser;
     }
 
-    public int getCode() {
-        return code;
+    public Optional<String> getCode() {
+        return Optional.ofNullable(code);
     }
 
     public boolean isShowHelp() {

--- a/src/main/java/codoc/logic/commands/ViewCommand.java
+++ b/src/main/java/codoc/logic/commands/ViewCommand.java
@@ -80,6 +80,7 @@ public class ViewCommand extends Command {
         model.setProtagonist(protagonist);
         String[] nameParsed = protagonist.getName().toString().split(" ", 2);
 
-        return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, nameParsed[0], index.getOneBased()));
+        return new CommandResult(String.format(MESSAGE_VIEW_PERSON_SUCCESS, nameParsed[0], index.getOneBased()),
+                false, false, String.valueOf(index.getZeroBased()));
     }
 }

--- a/src/main/java/codoc/ui/MainWindow.java
+++ b/src/main/java/codoc/ui/MainWindow.java
@@ -219,6 +219,10 @@ public class MainWindow extends UiPart<Stage> {
                 personListPanel.showLastItem();
             }
 
+            if (commandResult.getCode().isPresent()) {
+                personListPanel.showIndex(Integer.parseInt(commandResult.getCode().get()));
+            }
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("Invalid command: " + commandText);

--- a/src/main/java/codoc/ui/MainWindow.java
+++ b/src/main/java/codoc/ui/MainWindow.java
@@ -267,6 +267,10 @@ public class MainWindow extends UiPart<Stage> {
             executeCommand("view " + index);
         }
 
+        public void copyText(String attribute) {
+            resultDisplay.setFeedbackToUser("Copied " + attribute + " to clipboard!");
+        }
+
     }
 
 }

--- a/src/main/java/codoc/ui/PersonListPanel.java
+++ b/src/main/java/codoc/ui/PersonListPanel.java
@@ -31,10 +31,17 @@ public class PersonListPanel extends UiPart<Region> {
         personListView.setCellFactory(listView -> new PersonListViewCell());
     }
 
+    /**
+     * Scrolls itself to last person.
+     */
     public void showLastItem() {
         personListView.scrollTo(personListView.getItems().size() - 1);
     }
 
+    /**
+     * Scrolls itself to the given {@code index}. Selects and highlights the {@code index} too.
+     * @param index
+     */
     public void showIndex(int index) {
         personListView.scrollTo(index);
         personListView.getSelectionModel().select(index);

--- a/src/main/java/codoc/ui/PersonListPanel.java
+++ b/src/main/java/codoc/ui/PersonListPanel.java
@@ -35,6 +35,11 @@ public class PersonListPanel extends UiPart<Region> {
         personListView.scrollTo(personListView.getItems().size() - 1);
     }
 
+    public void showIndex(int index) {
+        personListView.scrollTo(index);
+        personListView.getSelectionModel().select(index);
+    }
+
     /**
      * Set UiEventListener for InfoTab.
      * @param listener

--- a/src/main/java/codoc/ui/infopanel/DetailedContact.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedContact.java
@@ -56,6 +56,7 @@ public class DetailedContact extends DetailedInfo {
         final ClipboardContent url = new ClipboardContent();
         url.putString(protagonist.getEmail().value);
         clipboard.setContent(url);
+        getListener().copyText("email address");
     }
     @FXML
     private void copyGithubUrl() {
@@ -63,6 +64,7 @@ public class DetailedContact extends DetailedInfo {
         final ClipboardContent url = new ClipboardContent();
         url.putString(protagonist.getGithub().value == null ? "" : "@" + protagonist.getGithub().value);
         clipboard.setContent(url);
+        getListener().copyText("GitHub URL");
     }
     @FXML
     private void copyLinkedinUrl() {
@@ -70,6 +72,7 @@ public class DetailedContact extends DetailedInfo {
         final ClipboardContent url = new ClipboardContent();
         url.putString(protagonist.getLinkedin().value == null ? "" : protagonist.getLinkedin().value);
         clipboard.setContent(url);
+        getListener().copyText("LinkedIn URL");
     }
 
 }

--- a/src/main/java/codoc/ui/infopanel/DetailedInfo.java
+++ b/src/main/java/codoc/ui/infopanel/DetailedInfo.java
@@ -27,6 +27,10 @@ public abstract class DetailedInfo extends UiPart<Region> {
         this.listener = listener;
     }
 
+    public MainWindow.ClickListener getListener() {
+        return listener;
+    }
+
     @FXML
     private void viewContactTab() throws CommandException, ParseException {
         listener.viewContact();

--- a/src/main/java/codoc/ui/infopanel/InfoTab.java
+++ b/src/main/java/codoc/ui/infopanel/InfoTab.java
@@ -12,6 +12,7 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import javafx.scene.text.Text;
 
 /**
  * Panel containing detailed information about a person.
@@ -28,7 +29,7 @@ public class InfoTab extends UiPart<Region> {
     private ImageView profilePicture;
 
     @FXML
-    private Label name;
+    private Text name;
 
     @FXML
     private Label identity;

--- a/src/main/resources/view/DetailedContact.fxml
+++ b/src/main/resources/view/DetailedContact.fxml
@@ -1,15 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.Cursor?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.shape.Rectangle?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.shape.*?>
 
-<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/19" xmlns:fx="http://javafx.com/fxml/1">
+<VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <children>
         <StackPane>
             <children>
@@ -18,7 +15,7 @@
                     <children>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #79addc; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Contact" textAlignment="CENTER">
+                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #79addc; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Contact" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -27,7 +24,7 @@
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Modules" textAlignment="CENTER">
+                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Modules" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -36,7 +33,7 @@
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Skills" textAlignment="CENTER">
+                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Skills" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -49,29 +46,29 @@
         </StackPane>
         <VBox prefHeight="200.0" prefWidth="100.0">
             <children>
-                <Label styleClass="label-bold" text="Email Address:" />
-                <HBox prefHeight="100.0" prefWidth="200.0" spacing="70.0">
-                    <children>
-                        <Label fx:id="email" prefWidth="140.0" text="\\\$email" wrapText="true" />
-                        <Button fx:id="copyEmailButton" mnemonicParsing="false" onAction="#copyEmailUrl" prefHeight="25.0" prefWidth="92.0" text="Copy Email" />
-                    </children>
-                </HBox>
-                <StackPane prefHeight="20.0" prefWidth="280.0" />
-                <Label styleClass="label-bold" text="GitHub:" />
-                <HBox prefHeight="100.0" prefWidth="200.0" spacing="70.0">
-                   <children>
-                          <Label fx:id="github" prefWidth="140.0" text="\\\$github_username" wrapText="true" />
-                          <Button fx:id="copyGithubButton" mnemonicParsing="false" onAction="#copyGithubUrl" prefHeight="25.0" prefWidth="92.0" text="Copy Github" />
-                   </children>
-                </HBox>
-                <StackPane layoutX="10.0" layoutY="38.0" prefHeight="20.0" prefWidth="300.0" />
-                <Label styleClass="label-bold" text="LinkedIn Profile:" />
-                <HBox prefHeight="100.0" prefWidth="200.0" spacing="70.0">
-                   <children>
-                          <Label fx:id="linkedin" prefWidth="132.0" text="\\\$linkedin_url" wrapText="true" />
-                          <Button fx:id="copyLinkedinButton" mnemonicParsing="false" onAction="#copyLinkedinUrl" prefHeight="25.0" prefWidth="99.0" text="Copy Linkedin" />
-                   </children>
-                </HBox>
+            <HBox alignment="CENTER_LEFT">
+               <children>
+                      <Label prefWidth="200.0" styleClass="label-bold" text="Email Address:" />
+                        <Button fx:id="copyEmailButton" mnemonicParsing="false" onAction="#copyEmailUrl" prefHeight="25.0" prefWidth="100.0" text="Copy Email" />
+               </children>
+            </HBox>
+                  <Label fx:id="email" text="\\\$email" wrapText="true" />
+                <StackPane prefHeight="40.0" prefWidth="300.0" />
+            <HBox alignment="CENTER_LEFT">
+               <children>
+                      <Label prefWidth="200.0" styleClass="label-bold" text="GitHub:" />
+                          <Button fx:id="copyGithubButton" mnemonicParsing="false" onAction="#copyGithubUrl" prefHeight="25.0" prefWidth="100.0" text="Copy Github" />
+               </children>
+            </HBox>
+                    <Label fx:id="github" text="\\\$github_username" wrapText="true" />
+                <StackPane layoutX="10.0" layoutY="38.0" prefHeight="40.0" prefWidth="300.0" />
+            <HBox alignment="CENTER_LEFT">
+               <children>
+                      <Label prefWidth="200.0" styleClass="label-bold" text="LinkedIn Profile:" />
+                          <Button fx:id="copyLinkedinButton" mnemonicParsing="false" onAction="#copyLinkedinUrl" prefHeight="25.0" prefWidth="100.0" text="Copy Linkedin" />
+               </children>
+            </HBox>
+                    <Label fx:id="linkedin" prefWidth="132.0" text="\\\$linkedin_url" wrapText="true" />
             </children>
             <VBox.margin>
                 <Insets left="10.0" right="10.0" top="1.0" />

--- a/src/main/resources/view/DetailedModule.fxml
+++ b/src/main/resources/view/DetailedModule.fxml
@@ -15,7 +15,7 @@
                     <children>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Contact" textAlignment="CENTER">
+                                <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Contact" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -24,7 +24,7 @@
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #ffc09f; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Modules" textAlignment="CENTER">
+                                <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #ffc09f; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Modules" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -33,7 +33,7 @@
                         </StackPane>
                         <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                             <children>
-                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Skills" textAlignment="CENTER">
+                                <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Skills" textAlignment="CENTER">
                                     <cursor>
                                         <Cursor fx:constant="HAND" />
                                     </cursor>
@@ -44,7 +44,7 @@
                 </HBox>
             </children>
         </StackPane>
-        <ListView fx:id="moduleListView" maxWidth="330" minHeight="340.0" style="-fx-background-color: derive(#ffc09f, 80%);" VBox.vgrow="ALWAYS" />
+        <ListView fx:id="moduleListView" maxWidth="330" style="-fx-background-color: derive(#ffc09f, 80%);" VBox.vgrow="ALWAYS" />
     </children>
     <padding>
         <Insets bottom="10.0" />

--- a/src/main/resources/view/DetailedSkill.fxml
+++ b/src/main/resources/view/DetailedSkill.fxml
@@ -1,13 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.Cursor?>
-<?import javafx.scene.control.Button?>
-<?import javafx.scene.control.ListView?>
-<?import javafx.scene.layout.HBox?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.shape.Rectangle?>
+<?import javafx.geometry.*?>
+<?import javafx.scene.*?>
+<?import javafx.scene.control.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.shape.*?>
 
 <VBox alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
    <children>
@@ -18,7 +15,7 @@
                <children>
                   <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                      <children>
-                        <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Contact" textAlignment="CENTER">
+                        <Button fx:id="contactButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewContactTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Contact" textAlignment="CENTER">
                            <cursor>
                               <Cursor fx:constant="HAND" />
                            </cursor>
@@ -27,7 +24,7 @@
                   </StackPane>
                   <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                      <children>
-                        <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Modules" textAlignment="CENTER">
+                        <Button fx:id="modulesButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewModulesTab" style="-fx-background-color: #f0f0f0; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Modules" textAlignment="CENTER">
                            <cursor>
                               <Cursor fx:constant="HAND" />
                            </cursor>
@@ -36,7 +33,7 @@
                   </StackPane>
                   <StackPane maxHeight="50" minHeight="50" minWidth="100.0">
                      <children>
-                        <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #ffee93; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light;" text="Skills" textAlignment="CENTER">
+                        <Button fx:id="skillsButton" maxHeight="30.0" minHeight="30.0" minWidth="100.0" onAction="#viewSkillsTab" style="-fx-background-color: #ffee93; -fx-background-radius: 10; -fx-border-color: transparent; -fx-text-fill: #555555; -fx-font-family: Roboto Light; -fx-font-size: 14;" text="Skills" textAlignment="CENTER">
                            <cursor>
                               <Cursor fx:constant="HAND" />
                            </cursor>
@@ -47,7 +44,7 @@
             </HBox>
          </children>
       </StackPane>
-      <ListView fx:id="skillListView" maxWidth="330" minHeight="340.0" style="-fx-background-color: derive(#ffee93, 50%);" VBox.vgrow="ALWAYS" />
+      <ListView fx:id="skillListView" maxWidth="330" style="-fx-background-color: derive(#ffee93, 50%);" VBox.vgrow="ALWAYS" />
    </children>
    <padding>
       <Insets bottom="10.0" />

--- a/src/main/resources/view/InfoTab.fxml
+++ b/src/main/resources/view/InfoTab.fxml
@@ -1,27 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.geometry.Insets?>
-<?import javafx.scene.control.Label?>
-<?import javafx.scene.image.ImageView?>
-<?import javafx.scene.layout.StackPane?>
-<?import javafx.scene.layout.VBox?>
-<?import javafx.scene.text.Font?>
-<VBox id="infoPane" fx:id="infoPane" alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8"
-      xmlns:fx="http://javafx.com/fxml/1">
+<?import javafx.scene.control.*?>
+<?import javafx.scene.image.*?>
+<?import javafx.scene.layout.*?>
+<?import javafx.scene.text.*?>
+
+<VBox id="infoPane" fx:id="infoPane" alignment="TOP_CENTER" VBox.vgrow="ALWAYS" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
     <children>
-        <ImageView fx:id="profilePicture" fitHeight="100.0" fitWidth="100.0">
-            <VBox.margin>
-                <Insets bottom="10.0" left="10.0" right="10.0" top="20.0"/>
-            </VBox.margin>
-        </ImageView>
-        <Label fx:id="name" alignment="CENTER" contentDisplay="CENTER" styleClass="label-header" text="Label"
-               textAlignment="CENTER" wrapText="true" VBox.vgrow="ALWAYS">
-        </Label>
+      <StackPane maxHeight="20.0" minHeight="20.0" />
+        <ImageView fx:id="profilePicture" fitHeight="100.0" fitWidth="100.0" />
+      <Text fx:id="name" strokeType="OUTSIDE" strokeWidth="0.0" styleClass="label-header" text="Name" textAlignment="CENTER" wrappingWidth="320.0" VBox.vgrow="ALWAYS" />
         <Label fx:id="identity" alignment="CENTER" text="Identity">
             <font>
-                <Font name="Roboto Light" size="12.0"/>
+                <Font name="Roboto Light" size="12.0" />
             </font>
         </Label>
-        <StackPane fx:id="detailedInfoPlaceholder" alignment="TOP_CENTER" minWidth="340" VBox.vgrow="ALWAYS"/>
+        <StackPane fx:id="detailedInfoPlaceholder" alignment="TOP_CENTER" minWidth="340" VBox.vgrow="SOMETIMES" />
     </children>
 </VBox>


### PR DESCRIPTION
Allowed ViewCommand to scroll down to the index and highlight it properly.
Previously, highlighting would only work if the person was clicked on through GUI.
Now, the ViewCommand's CommandResult passes through index of selected protagonist to the MainWindow with the `code` attribute, that is a String and hence can be wrapped in Optional class.

Updated MainWindow's click listener to handle Copy buttons under DetailedContact too.

Most importantly, name wrap has been fixed. The bug was from Label not being able to set its vertical size, despite having its VBox.vgrow set to "ALWAYS". This Label has been replaced with FXML shape Text, which does its job.