### PR TITLE
Limit name length to 50 characters

### DIFF
--- a/src/main/java/codoc/logic/parser/ParserUtil.java
+++ b/src/main/java/codoc/logic/parser/ParserUtil.java
@@ -25,6 +25,7 @@ import codoc.model.skill.Skill;
 public class ParserUtil {
 
     public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_NAME_TOO_LONG = "Name cannot be longer than 50 characters.";
 
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
@@ -48,6 +49,9 @@ public class ParserUtil {
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
         String trimmedName = name.trim();
+        if (trimmedName.length() > 50) {
+            throw new ParseException(MESSAGE_NAME_TOO_LONG);
+        }
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/codoc/logic/parser/ParserUtil.java
+++ b/src/main/java/codoc/logic/parser/ParserUtil.java
@@ -45,6 +45,7 @@ public class ParserUtil {
      * Leading and trailing whitespaces will be trimmed.
      *
      * @throws ParseException if the given {@code name} is invalid.
+     * @throws ParseException if the given {@code name} is longer than 50 characters.
      */
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);


### PR DESCRIPTION
Updated the ParserUtil to check if the name length is longer than 50 characters.

Throws a ParserUtil if so.