### PR TITLE
Fix wrong error message shown when edit was not made

### DIFF
--- a/src/main/java/codoc/logic/commands/EditCommand.java
+++ b/src/main/java/codoc/logic/commands/EditCommand.java
@@ -101,8 +101,11 @@ public class EditCommand extends Command {
 
         Person editedPerson = createEditedPerson(personToEdit, editPersonDescriptor);
 
-        if (personToEdit.equals(editedPerson)
-                || (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson))) {
+        if (personToEdit.equals(editedPerson)) {
+            throw new CommandException(MESSAGE_NOT_EDITED);
+        }
+
+        if (!personToEdit.isSamePerson(editedPerson) && model.hasPerson(editedPerson)) {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 


### PR DESCRIPTION
Closes #180 and #176.

Bug primary coming from checking both of the following at once:
1. Whether any edits were made.
2. Whether edited person is already existing in the database.

Simple fix: Separate them and throw already existing error message for when a person was not edited.