### PR TITLE
Remove unintended traverse function with keys on personListView

### DIFF
--- a/src/main/java/codoc/ui/PersonListPanel.java
+++ b/src/main/java/codoc/ui/PersonListPanel.java
@@ -5,9 +5,11 @@ import java.util.logging.Logger;
 import codoc.commons.core.LogsCenter;
 import codoc.model.person.Person;
 import javafx.collections.ObservableList;
+import javafx.event.Event;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 
 /**
@@ -29,6 +31,7 @@ public class PersonListPanel extends UiPart<Region> {
         ObservableList<Person> personList = mainWindow.getLogic().getFilteredPersonList();
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+        personListView.addEventFilter(KeyEvent.ANY, Event::consume);
     }
 
     /**


### PR DESCRIPTION
Closes #181.

Bug: Unintended GUI feature where user can traverse with the selection through the `personListView`.

Cause of bug: Default ListView behaviour not removed.

Fix: Add a empty consumer for key pressed event on ListView.