### PR TITLE
Add overflow check for index

### DIFF
--- a/src/main/java/codoc/logic/parser/ViewCommandParser.java
+++ b/src/main/java/codoc/logic/parser/ViewCommandParser.java
@@ -1,11 +1,14 @@
 package codoc.logic.parser;
 
 import static codoc.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static codoc.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static java.util.Objects.requireNonNull;
 
 import codoc.commons.core.index.Index;
 import codoc.logic.commands.ViewCommand;
 import codoc.logic.parser.exceptions.ParseException;
+
+import java.math.BigInteger;
 
 /**
  * Parses input arguments and creates a new ViewCommand object
@@ -33,9 +36,15 @@ public class ViewCommandParser implements Parser<ViewCommand> {
 
     private boolean isNumeric(String arg) {
         try {
-            int num = Integer.parseInt(arg);
-        } catch (NumberFormatException e) {
-            return false;
+            Index num = ParserUtil.parseIndex(arg);
+        } catch (ParseException e) { // Could be due to overflowing integer
+            try {
+                BigInteger val = new BigInteger(arg); // Try to use BigInteger
+                // If it can parse into BigInteger
+                return true;
+            } catch (NumberFormatException nfe) { // BigInteger fails too.
+                return false;
+            }
         }
         return true;
     }

--- a/src/main/java/codoc/logic/parser/ViewCommandParser.java
+++ b/src/main/java/codoc/logic/parser/ViewCommandParser.java
@@ -1,14 +1,13 @@
 package codoc.logic.parser;
 
 import static codoc.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static codoc.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static java.util.Objects.requireNonNull;
+
+import java.math.BigInteger;
 
 import codoc.commons.core.index.Index;
 import codoc.logic.commands.ViewCommand;
 import codoc.logic.parser.exceptions.ParseException;
-
-import java.math.BigInteger;
 
 /**
  * Parses input arguments and creates a new ViewCommand object


### PR DESCRIPTION
Closes #171.
Closes #193.

View command takes in two different types of parameter, integer (index) or string (c, m or s).
Parser uses `isNumeric` method to separate out those two cases using `Integer.parseInt()`. This is why `isNumeric` was returning false for integers that are overflowing.

This updates the method to further check if it was possible to parse into BigInteger.

